### PR TITLE
Allow numbers in team issue identifier

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -175,7 +175,7 @@ async function updateIssueState(
 }
 
 function isValidLinearId(id: string): boolean {
-  return /^[A-Za-z]{2,5}-[1-9][0-9]*$/.test(id);
+  return /^[A-Za-z0-9]{2,5}-[1-9][0-9]*$/.test(id);
 }
 
 async function getIssueId(providedId?: string): Promise<string | null> {
@@ -189,7 +189,7 @@ async function getIssueId(providedId?: string): Promise<string | null> {
   }
   const branch = await getCurrentBranch();
   if (!branch) return null;
-  const match = branch.match(/[a-zA-Z]{2,5}-[1-9][0-9]*/i);
+  const match = branch.match(/[a-zA-Z0-9]{2,5}-[1-9][0-9]*/i);
   return match ? match[0].toUpperCase() : null;
 }
 
@@ -199,7 +199,7 @@ async function getTeamId(): Promise<string | null> {
     return teamId.toUpperCase();
   }
   const dir = await getRepoDir();
-  const match = dir.match(/^[a-zA-Z]{2,5}/);
+  const match = dir.match(/^[a-zA-Z0-9]{2,5}/);
   return match ? match[0].toUpperCase() : null;
 }
 


### PR DESCRIPTION
Updates regex to allow numbers in issue identifiers

(my team's issue identifier is `4U`, so regex was failing for `linear issue view` with a branch like `4u-[issue-number]-some-feature`)