### PR TITLE
Support --head flag for GH commands

### DIFF
--- a/src/commands/issue/issue-pull-request.ts
+++ b/src/commands/issue/issue-pull-request.ts
@@ -21,8 +21,12 @@ export const pullRequestCommand = new Command()
     "--web",
     "Open the pull request in the browser after creating it",
   )
+  .option(
+    "--head <branch:string>",
+    "The branch that contains commits for your pull request",
+  )
   .arguments("[issueId:string]")
-  .action(async ({ base, draft, title: customTitle, web }, issueId) => {
+  .action(async ({ base, draft, title: customTitle, web, head }, issueId) => {
     const resolvedId = await getIssueIdentifier(issueId)
     if (!resolvedId) {
       console.error(
@@ -44,6 +48,7 @@ export const pullRequestCommand = new Command()
         "--body",
         url,
         ...(base ? ["--base", base] : []),
+        ...(head ? ["--head", head] : []),
         ...(draft ? ["--draft"] : []),
         ...(web ? ["--web"] : []),
       ],


### PR DESCRIPTION
Add a --head option to the issue-pull-request command and pass it through
to the underlying gh CLI invocation so callers can specify the branch that
contains commits for the pull request. This was needed to allow creating
PRs from a non-default head branch via this wrapper. The change adds the
option declaration and threads the head value into the action handler
and the generated gh command arguments.