### PR TITLE
[CLOSE] Opened by mistake

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -5,14 +5,14 @@
   "exports": "./src/main.ts",
   "license": "MIT",
   "tasks": {
-    "dev": "deno task codegen && deno run '--allow-env=GITHUB_*,GH_*,LINEAR_*,NODE_ENV,EDITOR,PAGER,NO_COLOR,TMPDIR,TMP,TEMP' --allow-read --allow-write --allow-run --allow-net=api.linear.app,uploads.linear.app --allow-sys=hostname --quiet src/main.ts ",
-    "install": "deno task codegen && deno install -c ./deno.json '--allow-env=GITHUB_*,GH_*,LINEAR_*,NODE_ENV,EDITOR,PAGER,NO_COLOR,TMPDIR,TMP,TEMP' --allow-read --allow-write --allow-run --allow-net=api.linear.app,uploads.linear.app --allow-sys=hostname --quiet -g -f -n linear ./src/main.ts",
+    "dev": "deno task codegen && deno run '--allow-env=GITHUB_*,GH_*,LINEAR_*,NODE_ENV,EDITOR,PAGER,NO_COLOR,TMPDIR,TMP,TEMP,HOME' --allow-read --allow-write --allow-run --allow-net=api.linear.app,uploads.linear.app --allow-sys=hostname --quiet src/main.ts ",
+    "install": "deno task codegen && deno install -c ./deno.json '--allow-env=GITHUB_*,GH_*,LINEAR_*,NODE_ENV,EDITOR,PAGER,NO_COLOR,TMPDIR,TMP,TEMP,HOME' --allow-read --allow-write --allow-run --allow-net=api.linear.app,uploads.linear.app --allow-sys=hostname --quiet -g -f -n linear ./src/main.ts",
     "uninstall": "deno uninstall -g linear",
     "sync-schema": "deno task dev schema -o graphql/schema.graphql",
     "codegen": "deno run --allow-all npm:@graphql-codegen/cli/graphql-codegen-esm",
     "check": "deno check src/main.ts",
-    "test": "deno test '--allow-env=GITHUB_*,GH_*,LINEAR_*,NODE_ENV,EDITOR,PAGER,SNAPSHOT_TEST_NAME,CLIFFY_SNAPSHOT_FAKE_TIME,NO_COLOR,TMPDIR,TMP,TEMP' --allow-read --allow-write --allow-run --allow-net=api.linear.app,uploads.linear.app --allow-sys=hostname --quiet",
-    "snapshot": "deno test '--allow-env=GITHUB_*,GH_*,LINEAR_*,NODE_ENV,EDITOR,PAGER,SNAPSHOT_TEST_NAME,CLIFFY_SNAPSHOT_FAKE_TIME,NO_COLOR,TMPDIR,TMP,TEMP' --allow-read --allow-write --allow-run --allow-net=api.linear.app,uploads.linear.app --allow-sys=hostname -- --update",
+    "test": "deno test '--allow-env=GITHUB_*,GH_*,LINEAR_*,NODE_ENV,EDITOR,PAGER,SNAPSHOT_TEST_NAME,CLIFFY_SNAPSHOT_FAKE_TIME,NO_COLOR,TMPDIR,TMP,TEMP,HOME' --allow-read --allow-write --allow-run --allow-net=api.linear.app,uploads.linear.app --allow-sys=hostname --quiet",
+    "snapshot": "deno test '--allow-env=GITHUB_*,GH_*,LINEAR_*,NODE_ENV,EDITOR,PAGER,SNAPSHOT_TEST_NAME,CLIFFY_SNAPSHOT_FAKE_TIME,NO_COLOR,TMPDIR,TMP,TEMP,HOME' --allow-read --allow-write --allow-run --allow-net=api.linear.app,uploads.linear.app --allow-sys=hostname -- --update",
     "lefthook-install": "deno run --allow-run --allow-read --allow-write --allow-env npm:lefthook install"
   },
   "imports": {

--- a/test/commands/issue/issue-commits.test.ts
+++ b/test/commands/issue/issue-commits.test.ts
@@ -3,7 +3,7 @@ import { commitsCommand } from "../../../src/commands/issue/issue-commits.ts"
 
 // Common Deno args for permissions
 const denoArgs = [
-  "--allow-env=GITHUB_*,GH_*,LINEAR_*,NODE_ENV,EDITOR,PAGER,SNAPSHOT_TEST_NAME,CLIFFY_SNAPSHOT_FAKE_TIME,NO_COLOR,TMPDIR,TMP,TEMP",
+  "--allow-env=GITHUB_*,GH_*,LINEAR_*,NODE_ENV,EDITOR,PAGER,SNAPSHOT_TEST_NAME,CLIFFY_SNAPSHOT_FAKE_TIME,NO_COLOR,TMPDIR,TMP,TEMP,HOME",
   "--allow-read",
   "--allow-write",
   "--allow-run",

--- a/test/commands/issue/issue-describe.test.ts
+++ b/test/commands/issue/issue-describe.test.ts
@@ -4,7 +4,7 @@ import { MockLinearServer } from "../../utils/mock_linear_server.ts"
 
 // Common Deno args for permissions
 const denoArgs = [
-  "--allow-env=GITHUB_*,GH_*,LINEAR_*,NODE_ENV,EDITOR,SNAPSHOT_TEST_NAME",
+  "--allow-env=GITHUB_*,GH_*,LINEAR_*,NODE_ENV,EDITOR,SNAPSHOT_TEST_NAME,HOME",
   "--allow-read",
   "--allow-write",
   "--allow-run",

--- a/test/commands/issue/issue-view.test.ts
+++ b/test/commands/issue/issue-view.test.ts
@@ -7,7 +7,7 @@ const TEST_ENDPOINT = "http://127.0.0.1:59123/graphql"
 
 // Common Deno args for permissions
 const denoArgs = [
-  "--allow-env=GITHUB_*,GH_*,LINEAR_*,NODE_ENV,EDITOR,PAGER,SNAPSHOT_TEST_NAME,CLIFFY_SNAPSHOT_FAKE_TIME,NO_COLOR,TMPDIR,TMP,TEMP",
+  "--allow-env=GITHUB_*,GH_*,LINEAR_*,NODE_ENV,EDITOR,PAGER,SNAPSHOT_TEST_NAME,CLIFFY_SNAPSHOT_FAKE_TIME,NO_COLOR,TMPDIR,TMP,TEMP,HOME",
   "--allow-read",
   "--allow-write",
   "--allow-run",

--- a/test/commands/project/project-view.test.ts
+++ b/test/commands/project/project-view.test.ts
@@ -4,7 +4,7 @@ import { MockLinearServer } from "../../utils/mock_linear_server.ts"
 
 // Common Deno args for permissions
 const denoArgs = [
-  "--allow-env=GITHUB_*,GH_*,LINEAR_*,NODE_ENV,EDITOR,SNAPSHOT_TEST_NAME",
+  "--allow-env=GITHUB_*,GH_*,LINEAR_*,NODE_ENV,EDITOR,SNAPSHOT_TEST_NAME,HOME",
   "--allow-read",
   "--allow-write",
   "--allow-run",

--- a/test/commands/team/team-list.test.ts
+++ b/test/commands/team/team-list.test.ts
@@ -5,7 +5,7 @@ import { MockLinearServer } from "../../utils/mock_linear_server.ts"
 
 // Common Deno args for permissions
 const denoArgs = [
-  "--allow-env=GITHUB_*,GH_*,LINEAR_*,NODE_ENV,EDITOR,SNAPSHOT_TEST_NAME,CLIFFY_SNAPSHOT_FAKE_TIME",
+  "--allow-env=GITHUB_*,GH_*,LINEAR_*,NODE_ENV,EDITOR,SNAPSHOT_TEST_NAME,CLIFFY_SNAPSHOT_FAKE_TIME,HOME",
   "--allow-read",
   "--allow-write",
   "--allow-run",

--- a/test/utils/test-helpers.ts
+++ b/test/utils/test-helpers.ts
@@ -2,7 +2,7 @@ import { MockLinearServer } from "./mock_linear_server.ts"
 
 // Common Deno args for permissions used across all tests
 export const commonDenoArgs = [
-  "--allow-env=GITHUB_*,GH_*,LINEAR_*,NODE_ENV,EDITOR,SNAPSHOT_TEST_NAME,MOCK_GIT_BRANCH_COMMAND,TEST_CURRENT_TIME,CLIFFY_SNAPSHOT_FAKE_TIME",
+  "--allow-env=GITHUB_*,GH_*,LINEAR_*,NODE_ENV,EDITOR,SNAPSHOT_TEST_NAME,MOCK_GIT_BRANCH_COMMAND,TEST_CURRENT_TIME,CLIFFY_SNAPSHOT_FAKE_TIME,HOME",
   "--allow-read",
   "--allow-write",
   "--allow-run",


### PR DESCRIPTION
Allow api_key to be read from ~/linear.toml, ~/.linear.toml, or
~/.config/linear.toml as a fallback when not found in project config
or environment variables. This enables users to set a global API key
without configuring it per-project.
