### PR TITLE
fix: environment variables now correctly take precedence over config file values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- environment variables now correctly take precedence over config file values
+
 ## [1.6.0] - 2026-01-05
 
 ### Added

--- a/src/config.ts
+++ b/src/config.ts
@@ -108,8 +108,9 @@ export type Options = v.InferOutput<typeof OptionsSchema>
 export type OptionName = keyof Options
 
 function getRawOption(optionName: OptionName, cliValue?: string): unknown {
-  return cliValue ?? config[optionName] ??
-    Deno.env.get("LINEAR_" + optionName.toUpperCase())
+  return cliValue ??
+    Deno.env.get("LINEAR_" + optionName.toUpperCase()) ??
+    config[optionName]
 }
 
 export function getOption<T extends OptionName>(

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -52,3 +52,105 @@ Deno.test("getOption - download_images returns undefined for unrecognized string
   const result = getOption("download_images", "maybe")
   assertEquals(result, undefined)
 })
+
+Deno.test("getOption - environment variables take precedence over config file", async () => {
+  // Create a temp directory with a config file
+  const tempDir = await Deno.makeTempDir()
+  const configValue = "from-config-file"
+  const envValue = "from-env-var"
+
+  try {
+    // Write a .linear.toml with a workspace value
+    await Deno.writeTextFile(
+      `${tempDir}/.linear.toml`,
+      `workspace = "${configValue}"\n`,
+    )
+
+    // Get absolute paths to the config module and deno.json
+    const configPath = new URL("../src/config.ts", import.meta.url).pathname
+    const denoJsonPath = new URL("../deno.json", import.meta.url).pathname
+
+    // Run a subprocess that imports config and prints the workspace value
+    // The subprocess runs from the temp directory so it loads our test config
+    const command = new Deno.Command("deno", {
+      args: [
+        "eval",
+        `--config=${denoJsonPath}`,
+        `import { getOption } from "file://${configPath}"; console.log(getOption("workspace") ?? "undefined");`,
+      ],
+      cwd: tempDir,
+      env: {
+        LINEAR_WORKSPACE: envValue,
+      },
+      stdout: "piped",
+      stderr: "piped",
+    })
+
+    const { stdout, stderr } = await command.output()
+    const output = new TextDecoder().decode(stdout).trim()
+    const errorOutput = new TextDecoder().decode(stderr)
+
+    if (errorOutput) {
+      console.error("Subprocess stderr:", errorOutput)
+    }
+
+    // The env var should win over the config file
+    assertEquals(
+      output,
+      envValue,
+      "Environment variable should take precedence over config file",
+    )
+  } finally {
+    // Clean up temp directory
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})
+
+Deno.test("getOption - config file is used when no env var is set", async () => {
+  // Create a temp directory with a config file
+  const tempDir = await Deno.makeTempDir()
+  const configValue = "from-config-file"
+
+  try {
+    // Write a .linear.toml with a workspace value
+    await Deno.writeTextFile(
+      `${tempDir}/.linear.toml`,
+      `workspace = "${configValue}"\n`,
+    )
+
+    // Get absolute paths to the config module and deno.json
+    const configPath = new URL("../src/config.ts", import.meta.url).pathname
+    const denoJsonPath = new URL("../deno.json", import.meta.url).pathname
+
+    // Run a subprocess without LINEAR_WORKSPACE env var
+    const command = new Deno.Command("deno", {
+      args: [
+        "eval",
+        `--config=${denoJsonPath}`,
+        `import { getOption } from "file://${configPath}"; console.log(getOption("workspace") ?? "undefined");`,
+      ],
+      cwd: tempDir,
+      env: {}, // No LINEAR_WORKSPACE set
+      stdout: "piped",
+      stderr: "piped",
+    })
+
+    const { stdout, stderr } = await command.output()
+    const output = new TextDecoder().decode(stdout).trim()
+    const errorOutput = new TextDecoder().decode(stderr)
+
+    if (errorOutput) {
+      console.error("Subprocess stderr:", errorOutput)
+    }
+
+    // The config file value should be used as fallback
+    assertEquals(
+      output,
+      configValue,
+      "Config file should be used when no env var is set",
+    )
+  } finally {
+    // Clean up temp directory
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})


### PR DESCRIPTION
## Summary

- Fixes precedence order in `getRawOption` so environment variables take priority over config file values, matching the README documentation
- Adds subprocess-based tests that verify the correct precedence behavior

## Details

The README states that "environment variables take precedence over config file values", but the code had the opposite behavior. This fix corrects the precedence order:

1. CLI flags (highest priority)
2. Environment variables
3. Config file (lowest priority)

## Test plan

- [x] Added test verifying env vars win when both env var and config file are present
- [x] Added test verifying config file is used as fallback when no env var is set
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)