### PR TITLE
feat: add --project filter to issue list command

### DIFF
--- a/src/utils/linear.ts
+++ b/src/utils/linear.ts
@@ -360,6 +360,7 @@ export async function fetchIssuesForState(
   unassigned = false,
   allAssignees = false,
   limit?: number,
+  projectId?: string,
 ) {
   const sort = getOption("issue_sort") as "manual" | "priority" | undefined
   if (!sort) {
@@ -389,6 +390,10 @@ export async function fetchIssuesForState(
     filter.assignee = { id: { eq: userId } }
   } else {
     filter.assignee = { isMe: { eq: true } }
+  }
+
+  if (projectId) {
+    filter.project = { id: { eq: projectId } }
   }
 
   const query = gql(/* GraphQL */ `

--- a/test/commands/issue/__snapshots__/issue-list.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-list.test.ts.snap
@@ -20,6 +20,7 @@ Options:
   -U, --unassigned                 - Show only unassigned issues                                                                                                  
   --sort               <sort>      - Sort order (can also be set via LINEAR_ISSUE_SORT)                    (Values: \\x1b[32m"manual"\\x1b[39m, \\x1b[32m"priority"\\x1b[39m)                         
   --team               <team>      - Team to list issues for (if not your default team)                                                                           
+  --project            <project>   - Filter by project name                                                                                                       
   --limit              <limit>     - Maximum number of issues to fetch (default: 50, use 0 for unlimited)  (Default: \\x1b[33m50\\x1b[39m)                                          
   -w, --web                        - Open in web browser                                                                                                          
   -a, --app                        - Open in Linear.app                                                                                                           


### PR DESCRIPTION
## Summary
- Adds `--project <project>` option to `linear issue list` command
- Filters issues by project name
- Uses interactive fuzzy search fallback if exact match not found (same pattern as `issue create`)

## Usage
```bash
linear issue list --project "My Project"
```

## Test plan
- [x] Snapshot test updated for help text
- [x] Lint passes
- [ ] Manual testing with real Linear workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)