### PR TITLE
feat: add multi-workspace authentication support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- built-in credential storage at `~/.config/linear/credentials.toml` for managing multiple Linear workspaces
+- `linear auth login` to add workspace credentials (auto-detects workspace from API key)
+- `linear auth logout` to remove workspace credentials
+- `linear auth list` to show configured workspaces with org/user info
+- `linear auth default` to set the default workspace
+- global `-w, --workspace` flag to target a specific workspace by slug
+
 ## [1.8.1] - 2026-01-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -66,24 +66,20 @@ deno task install
 
 1. create an API key at [linear.app/settings/account/security](https://linear.app/settings/account/security)[^1]
 
-2. add the API key to your shell environment:
+2. authenticate with the CLI:
 
    ```sh
-   # in ~/.bashrc or ~/.zshrc:
-   export LINEAR_API_KEY="lin_api_..."
-
-   # or in fish:
-   set -Ux LINEAR_API_KEY "lin_api_..."
+   linear auth login
    ```
 
-3. run the configuration wizard:
+3. configure your project:
 
    ```sh
    cd my-project-repo
    linear config
    ```
 
-   _this will create a `.linear.toml` config file in your repository with your workspace and team settings._
+see [docs/authentication.md](docs/authentication.md) for multi-workspace support and other authentication options.
 
 the CLI works with both git and jj version control systems:
 
@@ -209,8 +205,7 @@ the CLI supports configuration via environment variables or a `.linear.toml` con
 
 | option          | env var                  | toml key          | example                    | description                           |
 | --------------- | ------------------------ | ----------------- | -------------------------- | ------------------------------------- |
-| API key         | `LINEAR_API_KEY`         | `api_key`         | `"lin_api_..."`            | your Linear API key (required)        |
-| Team ID         | `LINEAR_TEAM_ID`         | `team_id`         | `"TEAM_abc123"`            | default team for operations           |
+| Team ID         | `LINEAR_TEAM_ID`         | `team_id`         | `"ENG"`                    | default team for operations           |
 | Workspace       | `LINEAR_WORKSPACE`       | `workspace`       | `"mycompany"`              | workspace slug for web/app URLs       |
 | Issue sort      | `LINEAR_ISSUE_SORT`      | `issue_sort`      | `"priority"` or `"manual"` | how to sort issue lists               |
 | VCS             | `LINEAR_VCS`             | `vcs`             | `"git"` or `"jj"`          | version control system (default: git) |

--- a/deno.lock
+++ b/deno.lock
@@ -3,12 +3,16 @@
   "specifiers": {
     "jsr:@cliffy/ansi@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cliffy/ansi@^1.0.0-rc.8": "1.0.0-rc.8",
+    "jsr:@cliffy/command@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/command@^1.0.0-rc.8": "1.0.0-rc.8",
+    "jsr:@cliffy/flags@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/flags@1.0.0-rc.8": "1.0.0-rc.8",
+    "jsr:@cliffy/internal@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/internal@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cliffy/internal@^1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cliffy/keycode@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cliffy/prompt@^1.0.0-rc.8": "1.0.0-rc.8",
+    "jsr:@cliffy/table@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/table@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cliffy/testing@^1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@littletof/charmd@*": "0.1.2",
@@ -77,13 +81,29 @@
         "jsr:@std/io"
       ]
     },
+    "@cliffy/command@1.0.0-rc.7": {
+      "integrity": "1288808d7a3cd18b86c24c2f920e47a6d954b7e23cadc35c8cbd78f8be41f0cd",
+      "dependencies": [
+        "jsr:@cliffy/flags@1.0.0-rc.7",
+        "jsr:@cliffy/internal@1.0.0-rc.7",
+        "jsr:@cliffy/table@1.0.0-rc.7",
+        "jsr:@std/fmt@~1.0.2",
+        "jsr:@std/text"
+      ]
+    },
     "@cliffy/command@1.0.0-rc.8": {
       "integrity": "758147790797c74a707e5294cc7285df665422a13d2a483437092ffce40b5557",
       "dependencies": [
-        "jsr:@cliffy/flags",
+        "jsr:@cliffy/flags@1.0.0-rc.8",
         "jsr:@cliffy/internal@1.0.0-rc.8",
-        "jsr:@cliffy/table",
+        "jsr:@cliffy/table@1.0.0-rc.8",
         "jsr:@std/fmt@~1.0.2",
+        "jsr:@std/text"
+      ]
+    },
+    "@cliffy/flags@1.0.0-rc.7": {
+      "integrity": "318d9be98f6a6417b108e03dec427dea96cdd41a15beb21d2554ae6da450a781",
+      "dependencies": [
         "jsr:@std/text"
       ]
     },
@@ -92,6 +112,9 @@
       "dependencies": [
         "jsr:@std/text"
       ]
+    },
+    "@cliffy/internal@1.0.0-rc.7": {
+      "integrity": "10412636ab3e67517d448be9eaab1b70c88eba9be22617b5d146257a11cc9b17"
     },
     "@cliffy/internal@1.0.0-rc.8": {
       "integrity": "34cdf2fad9b084b5aed493b138d573f52d4e988767215f7460daf0b918ff43d8",
@@ -113,6 +136,12 @@
         "jsr:@std/io",
         "jsr:@std/path@~1.0.6",
         "jsr:@std/text"
+      ]
+    },
+    "@cliffy/table@1.0.0-rc.7": {
+      "integrity": "9fdd9776eda28a0b397981c400eeb1aa36da2371b43eefe12e6ff555290e3180",
+      "dependencies": [
+        "jsr:@std/fmt@~1.0.2"
       ]
     },
     "@cliffy/table@1.0.0-rc.8": {

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,130 @@
+# authentication
+
+the CLI supports multiple authentication methods with the following precedence:
+
+1. `--api-key` flag (explicit key for single command)
+2. `LINEAR_API_KEY` environment variable
+3. `api_key` in project `.linear.toml` config
+4. `--workspace` / `-w` flag → stored credentials lookup
+5. project's `workspace` config → stored credentials lookup
+6. default workspace from stored credentials
+
+## stored credentials (recommended)
+
+credentials are stored in `~/.config/linear/credentials.toml` and support multiple workspaces.
+
+### commands
+
+```bash
+linear auth login              # add a workspace (prompts for API key)
+linear auth login --key <key>  # add with key directly (for scripts)
+linear auth list               # list configured workspaces
+linear auth default            # interactively set default workspace
+linear auth default <slug>     # set default workspace directly
+linear auth logout <slug>      # remove a workspace
+linear auth logout <slug> -f   # remove without confirmation
+linear auth whoami             # show current user and workspace
+linear auth token              # print the resolved API key
+```
+
+### adding workspaces
+
+```bash
+# first workspace becomes the default
+$ linear auth login
+Enter your Linear API key: ***
+Logged in to workspace: Acme Corp (acme)
+  User: Jane Developer <jane@acme.com>
+  Set as default workspace
+
+# add additional workspaces
+$ linear auth login
+Enter your Linear API key: ***
+Logged in to workspace: Side Project (side-project)
+  User: Jane Developer <jane@example.com>
+```
+
+### listing workspaces
+
+```bash
+$ linear auth list
+  WORKSPACE    ORG NAME      USER
+* acme         Acme Corp     Jane Developer <jane@acme.com>
+  side-project Side Project  Jane Developer <jane@example.com>
+```
+
+the `*` indicates the default workspace.
+
+### switching workspaces
+
+```bash
+# set a new default
+linear auth default side-project
+
+# or use -w flag for a single command
+linear -w side-project issue list
+linear -w acme issue create --title "Bug fix"
+```
+
+### credentials file format
+
+```toml
+# ~/.config/linear/credentials.toml
+default = "acme"
+acme = "lin_api_xxx"
+side-project = "lin_api_yyy"
+```
+
+## environment variable
+
+for simpler setups or CI environments, you can use an environment variable:
+
+```sh
+# bash/zsh
+export LINEAR_API_KEY="lin_api_..."
+
+# fish
+set -Ux LINEAR_API_KEY "lin_api_..."
+```
+
+this takes precedence over stored credentials. if you have `LINEAR_API_KEY` set and try to use `linear auth login`, you'll see a warning:
+
+```
+Warning: LINEAR_API_KEY environment variable is set.
+It takes precedence over stored credentials.
+Remove it from your shell config to use multi-workspace auth.
+```
+
+## project config
+
+you can also set the API key in a project's `.linear.toml`:
+
+```toml
+api_key = "lin_api_..."
+workspace = "acme"
+team_id = "ENG"
+```
+
+this is useful for project-specific credentials but less secure than stored credentials since it may be committed to version control.
+
+## workspace matching
+
+when your project config has a `workspace` setting:
+
+```toml
+# .linear.toml
+workspace = "acme"
+team_id = "ENG"
+```
+
+the CLI will automatically use the stored credentials for that workspace, even if a different workspace is your default. this lets you work on multiple projects with different workspaces without constantly switching.
+
+## creating an API key
+
+1. go to [linear.app/settings/account/security](https://linear.app/settings/account/security)
+2. scroll to "Personal API keys"
+3. click "Create key"
+4. give it a label (e.g., "CLI")
+5. copy the key (starts with `lin_api_`)
+
+note: creating an API key requires member access; it is not available for guest accounts.

--- a/skills/linear-cli/SKILL.md
+++ b/skills/linear-cli/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(linear:*), Bash(curl:*)
 
 A CLI to manage Linear issues from the command line, with git and jj integration.
 
-Generated from linear CLI v1.8.0
+Generated from linear CLI v1.8.1
 
 ## Prerequisites
 

--- a/skills/linear-cli/references/auth.md
+++ b/skills/linear-cli/references/auth.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear auth
-Version: 1.8.0      
+Version: 1.8.1      
 
 Description:
 
@@ -14,15 +14,94 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.  
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
 
 Commands:
 
-  token   - Print the configured API token                
-  whoami  - Print information about the authenticated user
+  login                 - Add a workspace credential                    
+  logout   [workspace]  - Remove a workspace credential                 
+  list                  - List configured workspaces                    
+  default  [workspace]  - Set the default workspace                     
+  token                 - Print the configured API token                
+  whoami                - Print information about the authenticated user
 ```
 
 ## Subcommands
+
+### login
+
+> Add a workspace credential
+
+```
+Usage:   linear auth login
+Version: 1.8.1            
+
+Description:
+
+  Add a workspace credential
+
+Options:
+
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
+  -k, --key        <key>   - API key (prompted if not provided)
+```
+
+### logout
+
+> Remove a workspace credential
+
+```
+Usage:   linear auth logout [workspace]
+Version: 1.8.1                         
+
+Description:
+
+  Remove a workspace credential
+
+Options:
+
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
+  -f, --force              - Skip confirmation prompt
+```
+
+### list
+
+> List configured workspaces
+
+```
+Usage:   linear auth list
+Version: 1.8.1           
+
+Description:
+
+  List configured workspaces
+
+Options:
+
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)
+```
+
+### default
+
+> Set the default workspace
+
+```
+Usage:   linear auth default [workspace]
+Version: 1.8.1                          
+
+Description:
+
+  Set the default workspace
+
+Options:
+
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)
+```
 
 ### token
 
@@ -30,7 +109,7 @@ Commands:
 
 ```
 Usage:   linear auth token
-Version: 1.8.0            
+Version: 1.8.1            
 
 Description:
 
@@ -38,7 +117,8 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)
 ```
 
 ### whoami
@@ -47,7 +127,7 @@ Options:
 
 ```
 Usage:   linear auth whoami
-Version: 1.8.0             
+Version: 1.8.1             
 
 Description:
 
@@ -55,5 +135,6 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)
 ```

--- a/skills/linear-cli/references/commands.md
+++ b/skills/linear-cli/references/commands.md
@@ -1,6 +1,6 @@
 # Linear CLI Command Reference
 
-Generated from linear CLI v1.8.0
+Generated from linear CLI v1.8.1
 
 ## Commands
 

--- a/skills/linear-cli/references/config.md
+++ b/skills/linear-cli/references/config.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear config
-Version: 1.8.0        
+Version: 1.8.1        
 
 Description:
 
@@ -14,5 +14,6 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)
 ```

--- a/skills/linear-cli/references/document.md
+++ b/skills/linear-cli/references/document.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear document
-Version: 1.8.0          
+Version: 1.8.1          
 
 Description:
 
@@ -14,7 +14,8 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.  
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
 
 Commands:
 
@@ -33,7 +34,7 @@ Commands:
 
 ```
 Usage:   linear document list
-Version: 1.8.0               
+Version: 1.8.1               
 
 Description:
 
@@ -41,11 +42,12 @@ Description:
 
 Options:
 
-  -h, --help             - Show this help.                                        
-  --project   <project>  - Filter by project (slug or name)                       
-  --issue     <issue>    - Filter by issue (identifier like TC-123)               
-  --json                 - Output as JSON                                         
-  --limit     <limit>    - Limit results                             (Default: 50)
+  -h, --help                  - Show this help.                                        
+  -w, --workspace  <slug>     - Target workspace (uses credentials)                    
+  --project        <project>  - Filter by project (slug or name)                       
+  --issue          <issue>    - Filter by issue (identifier like TC-123)               
+  --json                      - Output as JSON                                         
+  --limit          <limit>    - Limit results                             (Default: 50)
 ```
 
 ### view
@@ -54,7 +56,7 @@ Options:
 
 ```
 Usage:   linear document view <id>
-Version: 1.8.0                    
+Version: 1.8.1                    
 
 Description:
 
@@ -62,10 +64,11 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.                        
-  --raw       - Output raw markdown without rendering  
-  -w, --web   - Open document in browser               
-  --json      - Output full document as JSON
+  -h, --help               - Show this help.                        
+  -w, --workspace  <slug>  - Target workspace (uses credentials)    
+  --raw                    - Output raw markdown without rendering  
+  -w, --web                - Open document in browser               
+  --json                   - Output full document as JSON
 ```
 
 ### create
@@ -74,7 +77,7 @@ Options:
 
 ```
 Usage:   linear document create
-Version: 1.8.0                 
+Version: 1.8.1                 
 
 Description:
 
@@ -83,6 +86,7 @@ Description:
 Options:
 
   -h, --help                     - Show this help.                           
+  -w, --workspace     <slug>     - Target workspace (uses credentials)       
   -t, --title         <title>    - Document title (required)                 
   -c, --content       <content>  - Markdown content (inline)                 
   -f, --content-file  <path>     - Read content from file                    
@@ -99,7 +103,7 @@ Options:
 
 ```
 Usage:   linear document update <documentId>
-Version: 1.8.0                              
+Version: 1.8.1                              
 
 Description:
 
@@ -108,6 +112,7 @@ Description:
 Options:
 
   -h, --help                     - Show this help.                              
+  -w, --workspace     <slug>     - Target workspace (uses credentials)          
   -t, --title         <title>    - New title for the document                   
   -c, --content       <content>  - New markdown content (inline)                
   -f, --content-file  <path>     - Read new content from file                   
@@ -122,7 +127,7 @@ Options:
 
 ```
 Usage:   linear document delete [documentId]
-Version: 1.8.0                              
+Version: 1.8.1                              
 
 Description:
 
@@ -130,10 +135,11 @@ Description:
 
 Options:
 
-  -h, --help              - Show this help.                                     
-  -y, --yes               - Skip confirmation prompt                            
-  --no-color              - Disable colored output                              
-  --bulk        <ids...>  - Delete multiple documents by slug or ID             
-  --bulk-file   <file>    - Read document slugs/IDs from a file (one per line)  
-  --bulk-stdin            - Read document slugs/IDs from stdin
+  -h, --help                 - Show this help.                                     
+  -w, --workspace  <slug>    - Target workspace (uses credentials)                 
+  -y, --yes                  - Skip confirmation prompt                            
+  --no-color                 - Disable colored output                              
+  --bulk           <ids...>  - Delete multiple documents by slug or ID             
+  --bulk-file      <file>    - Read document slugs/IDs from a file (one per line)  
+  --bulk-stdin               - Read document slugs/IDs from stdin
 ```

--- a/skills/linear-cli/references/initiative-update.md
+++ b/skills/linear-cli/references/initiative-update.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear initiative-update
-Version: 1.8.0                   
+Version: 1.8.1                   
 
 Description:
 
@@ -14,7 +14,8 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.  
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
 
 Commands:
 
@@ -30,7 +31,7 @@ Commands:
 
 ```
 Usage:   linear initiative-update create <initiativeId>
-Version: 1.8.0                                         
+Version: 1.8.1                                         
 
 Description:
 
@@ -39,6 +40,7 @@ Description:
 Options:
 
   -h, --help                   - Show this help.                            
+  -w, --workspace    <slug>    - Target workspace (uses credentials)        
   --body             <body>    - Update content (markdown)                  
   --body-file        <path>    - Read content from file                     
   --health           <health>  - Health status (onTrack, atRisk, offTrack)  
@@ -52,7 +54,7 @@ Options:
 
 ```
 Usage:   linear initiative-update list <initiativeId>
-Version: 1.8.0                                       
+Version: 1.8.1                                       
 
 Description:
 
@@ -60,7 +62,8 @@ Description:
 
 Options:
 
-  -h, --help           - Show this help.               
-  -j, --json           - Output as JSON                
-  --limit     <limit>  - Limit results    (Default: 10)
+  -h, --help                - Show this help.                                   
+  -w, --workspace  <slug>   - Target workspace (uses credentials)               
+  -j, --json                - Output as JSON                                    
+  --limit          <limit>  - Limit results                        (Default: 10)
 ```

--- a/skills/linear-cli/references/initiative.md
+++ b/skills/linear-cli/references/initiative.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear initiative
-Version: 1.8.0            
+Version: 1.8.1            
 
 Description:
 
@@ -14,7 +14,8 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.  
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
 
 Commands:
 
@@ -37,7 +38,7 @@ Commands:
 
 ```
 Usage:   linear initiative list
-Version: 1.8.0                 
+Version: 1.8.1                 
 
 Description:
 
@@ -45,14 +46,15 @@ Description:
 
 Options:
 
-  -h, --help                - Show this help.                                
-  -s, --status    <status>  - Filter by status (active, planned, completed)  
-  --all-statuses            - Show all statuses (default: active only)       
-  -o, --owner     <owner>   - Filter by owner (username or email)            
-  -w, --web                 - Open initiatives page in web browser           
-  -a, --app                 - Open initiatives page in Linear.app            
-  -j, --json                - Output as JSON                                 
-  --archived                - Include archived initiatives
+  -h, --help                 - Show this help.                                
+  -w, --workspace  <slug>    - Target workspace (uses credentials)            
+  -s, --status     <status>  - Filter by status (active, planned, completed)  
+  --all-statuses             - Show all statuses (default: active only)       
+  -o, --owner      <owner>   - Filter by owner (username or email)            
+  -w, --web                  - Open initiatives page in web browser           
+  -a, --app                  - Open initiatives page in Linear.app            
+  -j, --json                 - Output as JSON                                 
+  --archived                 - Include archived initiatives
 ```
 
 ### view
@@ -61,7 +63,7 @@ Options:
 
 ```
 Usage:   linear initiative view <initiativeId>
-Version: 1.8.0                                
+Version: 1.8.1                                
 
 Description:
 
@@ -69,10 +71,11 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.      
-  -w, --web   - Open in web browser  
-  -a, --app   - Open in Linear.app   
-  -j, --json  - Output as JSON
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
+  -w, --web                - Open in web browser                  
+  -a, --app                - Open in Linear.app                   
+  -j, --json               - Output as JSON
 ```
 
 ### create
@@ -81,7 +84,7 @@ Options:
 
 ```
 Usage:   linear initiative create
-Version: 1.8.0                   
+Version: 1.8.1                   
 
 Description:
 
@@ -90,6 +93,7 @@ Description:
 Options:
 
   -h, --help                        - Show this help.                                        
+  -w, --workspace    <slug>         - Target workspace (uses credentials)                    
   -n, --name         <name>         - Initiative name (required)                             
   -d, --description  <description>  - Initiative description                                 
   -s, --status       <status>       - Status: planned, active, completed (default: planned)  
@@ -107,7 +111,7 @@ Options:
 
 ```
 Usage:   linear initiative archive [initiativeId]
-Version: 1.8.0                                   
+Version: 1.8.1                                   
 
 Description:
 
@@ -115,12 +119,13 @@ Description:
 
 Options:
 
-  -h, --help              - Show this help.                                    
-  -y, --force             - Skip confirmation prompt                           
-  --no-color              - Disable colored output                             
-  --bulk        <ids...>  - Archive multiple initiatives by ID, slug, or name  
-  --bulk-file   <file>    - Read initiative IDs from a file (one per line)     
-  --bulk-stdin            - Read initiative IDs from stdin
+  -h, --help                 - Show this help.                                    
+  -w, --workspace  <slug>    - Target workspace (uses credentials)                
+  -y, --force                - Skip confirmation prompt                           
+  --no-color                 - Disable colored output                             
+  --bulk           <ids...>  - Archive multiple initiatives by ID, slug, or name  
+  --bulk-file      <file>    - Read initiative IDs from a file (one per line)     
+  --bulk-stdin               - Read initiative IDs from stdin
 ```
 
 ### update
@@ -129,7 +134,7 @@ Options:
 
 ```
 Usage:   linear initiative update <initiativeId>
-Version: 1.8.0                                  
+Version: 1.8.1                                  
 
 Description:
 
@@ -138,6 +143,7 @@ Description:
 Options:
 
   -h, --help                        - Show this help.                                  
+  -w, --workspace    <slug>         - Target workspace (uses credentials)              
   -n, --name         <name>         - New name for the initiative                      
   -d, --description  <description>  - New description                                  
   --status           <status>       - New status (planned, active, completed, paused)  
@@ -155,7 +161,7 @@ Options:
 
 ```
 Usage:   linear initiative unarchive <initiativeId>
-Version: 1.8.0                                     
+Version: 1.8.1                                     
 
 Description:
 
@@ -163,9 +169,10 @@ Description:
 
 Options:
 
-  -h, --help   - Show this help.           
-  -y, --force  - Skip confirmation prompt  
-  --no-color   - Disable colored output
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
+  -y, --force              - Skip confirmation prompt             
+  --no-color               - Disable colored output
 ```
 
 ### delete
@@ -174,7 +181,7 @@ Options:
 
 ```
 Usage:   linear initiative delete [initiativeId]
-Version: 1.8.0                                  
+Version: 1.8.1                                  
 
 Description:
 
@@ -182,12 +189,13 @@ Description:
 
 Options:
 
-  -h, --help              - Show this help.                                   
-  -y, --force             - Skip confirmation prompt                          
-  --no-color              - Disable colored output                            
-  --bulk        <ids...>  - Delete multiple initiatives by ID, slug, or name  
-  --bulk-file   <file>    - Read initiative IDs from a file (one per line)    
-  --bulk-stdin            - Read initiative IDs from stdin
+  -h, --help                 - Show this help.                                   
+  -w, --workspace  <slug>    - Target workspace (uses credentials)               
+  -y, --force                - Skip confirmation prompt                          
+  --no-color                 - Disable colored output                            
+  --bulk           <ids...>  - Delete multiple initiatives by ID, slug, or name  
+  --bulk-file      <file>    - Read initiative IDs from a file (one per line)    
+  --bulk-stdin               - Read initiative IDs from stdin
 ```
 
 ### add-project
@@ -196,7 +204,7 @@ Options:
 
 ```
 Usage:   linear initiative add-project <initiative> <project>
-Version: 1.8.0                                               
+Version: 1.8.1                                               
 
 Description:
 
@@ -204,9 +212,10 @@ Description:
 
 Options:
 
-  -h, --help                 - Show this help.               
-  --sort-order  <sortOrder>  - Sort order within initiative  
-  --no-color                 - Disable colored output
+  -h, --help                    - Show this help.                      
+  -w, --workspace  <slug>       - Target workspace (uses credentials)  
+  --sort-order     <sortOrder>  - Sort order within initiative         
+  --no-color                    - Disable colored output
 ```
 
 ### remove-project
@@ -215,7 +224,7 @@ Options:
 
 ```
 Usage:   linear initiative remove-project <initiative> <project>
-Version: 1.8.0                                                  
+Version: 1.8.1                                                  
 
 Description:
 
@@ -223,7 +232,8 @@ Description:
 
 Options:
 
-  -h, --help   - Show this help.           
-  -y, --force  - Skip confirmation prompt  
-  --no-color   - Disable colored output
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
+  -y, --force              - Skip confirmation prompt             
+  --no-color               - Disable colored output
 ```

--- a/skills/linear-cli/references/issue.md
+++ b/skills/linear-cli/references/issue.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear issue
-Version: 1.8.0       
+Version: 1.8.1       
 
 Description:
 
@@ -14,7 +14,8 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.  
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
 
 Commands:
 
@@ -41,7 +42,7 @@ Commands:
 
 ```
 Usage:   linear issue id
-Version: 1.8.0          
+Version: 1.8.1          
 
 Description:
 
@@ -49,7 +50,8 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)
 ```
 
 ### list
@@ -58,7 +60,7 @@ Options:
 
 ```
 Usage:   linear issue list
-Version: 1.8.0            
+Version: 1.8.1            
 
 Description:
 
@@ -67,6 +69,7 @@ Description:
 Options:
 
   -h, --help                       - Show this help.                                                                                                              
+  -w, --workspace      <slug>      - Target workspace (uses credentials)                                                                                          
   -s, --state          <state>     - Filter by issue state (can be repeated for multiple states)           (Default: [ "unstarted" ], Values: "triage", "backlog",
                                                                                                            "unstarted", "started", "completed", "canceled")       
   --all-states                     - Show issues from all states                                                                                                  
@@ -88,7 +91,7 @@ Options:
 
 ```
 Usage:   linear issue title [issueId]
-Version: 1.8.0                       
+Version: 1.8.1                       
 
 Description:
 
@@ -96,7 +99,8 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)
 ```
 
 ### start
@@ -105,7 +109,7 @@ Options:
 
 ```
 Usage:   linear issue start [issueId]
-Version: 1.8.0                       
+Version: 1.8.1                       
 
 Description:
 
@@ -114,6 +118,7 @@ Description:
 Options:
 
   -h, --help                      - Show this help.                                            
+  -w, --workspace      <slug>     - Target workspace (uses credentials)                        
   -A, --all-assignees             - Show issues for all assignees                              
   -U, --unassigned                - Show only unassigned issues                                
   -f, --from-ref       <fromRef>  - Git ref to create new branch from                          
@@ -126,7 +131,7 @@ Options:
 
 ```
 Usage:   linear issue view [issueId]
-Version: 1.8.0                      
+Version: 1.8.1                      
 
 Description:
 
@@ -134,13 +139,14 @@ Description:
 
 Options:
 
-  -h, --help     - Show this help.                                
-  -w, --web      - Open in web browser                            
-  -a, --app      - Open in Linear.app                             
-  --no-comments  - Exclude comments from the output               
-  --no-pager     - Disable automatic paging for long output       
-  -j, --json     - Output issue data as JSON                      
-  --no-download  - Keep remote URLs instead of downloading files
+  -h, --help               - Show this help.                                
+  -w, --workspace  <slug>  - Target workspace (uses credentials)            
+  -w, --web                - Open in web browser                            
+  -a, --app                - Open in Linear.app                             
+  --no-comments            - Exclude comments from the output               
+  --no-pager               - Disable automatic paging for long output       
+  -j, --json               - Output issue data as JSON                      
+  --no-download            - Keep remote URLs instead of downloading files
 ```
 
 ### url
@@ -149,7 +155,7 @@ Options:
 
 ```
 Usage:   linear issue url [issueId]
-Version: 1.8.0                     
+Version: 1.8.1                     
 
 Description:
 
@@ -157,7 +163,8 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)
 ```
 
 ### describe
@@ -166,7 +173,7 @@ Options:
 
 ```
 Usage:   linear issue describe [issueId]
-Version: 1.8.0                          
+Version: 1.8.1                          
 
 Description:
 
@@ -174,8 +181,9 @@ Description:
 
 Options:
 
-  -h, --help               - Show this help.                                                
-  -r, --references, --ref  - Use 'References' instead of 'Fixes' for the Linear issue link
+  -h, --help                       - Show this help.                                                
+  -w, --workspace          <slug>  - Target workspace (uses credentials)                            
+  -r, --references, --ref          - Use 'References' instead of 'Fixes' for the Linear issue link
 ```
 
 ### commits
@@ -184,7 +192,7 @@ Options:
 
 ```
 Usage:   linear issue commits [issueId]
-Version: 1.8.0                         
+Version: 1.8.1                         
 
 Description:
 
@@ -192,7 +200,8 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)
 ```
 
 ### pull-request
@@ -201,7 +210,7 @@ Options:
 
 ```
 Usage:   linear issue pull-request [issueId]
-Version: 1.8.0                              
+Version: 1.8.1                              
 
 Description:
 
@@ -209,12 +218,13 @@ Description:
 
 Options:
 
-  -h, --help             - Show this help.                                                         
-  --base       <branch>  - The branch into which you want your code merged                         
-  --draft                - Create the pull request as a draft                                      
-  -t, --title  <title>   - Optional title for the pull request (Linear issue ID will be prefixed)  
-  --web                  - Open the pull request in the browser after creating it                  
-  --head       <branch>  - The branch that contains commits for your pull request
+  -h, --help                 - Show this help.                                                         
+  -w, --workspace  <slug>    - Target workspace (uses credentials)                                     
+  --base           <branch>  - The branch into which you want your code merged                         
+  --draft                    - Create the pull request as a draft                                      
+  -t, --title      <title>   - Optional title for the pull request (Linear issue ID will be prefixed)  
+  --web                      - Open the pull request in the browser after creating it                  
+  --head           <branch>  - The branch that contains commits for your pull request
 ```
 
 ### delete
@@ -223,7 +233,7 @@ Options:
 
 ```
 Usage:   linear issue delete [issueId]
-Version: 1.8.0                        
+Version: 1.8.1                        
 
 Description:
 
@@ -231,12 +241,13 @@ Description:
 
 Options:
 
-  -h, --help               - Show this help.                                             
-  -y, --confirm            - Skip confirmation prompt                                    
-  --no-color               - Disable colored output                                      
-  --bulk         <ids...>  - Delete multiple issues by identifier (e.g., TC-123 TC-124)  
-  --bulk-file    <file>    - Read issue identifiers from a file (one per line)           
-  --bulk-stdin             - Read issue identifiers from stdin
+  -h, --help                 - Show this help.                                             
+  -w, --workspace  <slug>    - Target workspace (uses credentials)                         
+  -y, --confirm              - Skip confirmation prompt                                    
+  --no-color                 - Disable colored output                                      
+  --bulk           <ids...>  - Delete multiple issues by identifier (e.g., TC-123 TC-124)  
+  --bulk-file      <file>    - Read issue identifiers from a file (one per line)           
+  --bulk-stdin               - Read issue identifiers from stdin
 ```
 
 ### create
@@ -245,7 +256,7 @@ Options:
 
 ```
 Usage:   linear issue create
-Version: 1.8.0              
+Version: 1.8.1              
 
 Description:
 
@@ -254,6 +265,7 @@ Description:
 Options:
 
   -h, --help                                - Show this help.                                              
+  -w, --workspace            <slug>         - Target workspace (uses credentials)                          
   --start                                   - Start the issue after creation                               
   -a, --assignee             <assignee>     - Assign the issue to 'self' or someone (by username or name)  
   --due-date                 <dueDate>      - Due date of the issue                                        
@@ -277,7 +289,7 @@ Options:
 
 ```
 Usage:   linear issue update [issueId]
-Version: 1.8.0                        
+Version: 1.8.1                        
 
 Description:
 
@@ -286,6 +298,7 @@ Description:
 Options:
 
   -h, --help                        - Show this help.                                              
+  -w, --workspace    <slug>         - Target workspace (uses credentials)                          
   -a, --assignee     <assignee>     - Assign the issue to 'self' or someone (by username or name)  
   --due-date         <dueDate>      - Due date of the issue                                        
   -p, --parent       <parent>       - Parent issue (if any) as a team_number code                  
@@ -306,7 +319,7 @@ Options:
 
 ```
 Usage:   linear issue comment
-Version: 1.8.0               
+Version: 1.8.1               
 
 Description:
 
@@ -314,7 +327,8 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.  
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
 
 Commands:
 
@@ -329,7 +343,7 @@ Commands:
 
 ```
 Usage:   linear issue comment add [issueId]
-Version: 1.8.0                             
+Version: 1.8.1                             
 
 Description:
 
@@ -337,16 +351,17 @@ Description:
 
 Options:
 
-  -h, --help            - Show this help.                
-  -b, --body    <text>  - Comment body text              
-  -p, --parent  <id>    - Parent comment ID for replies
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
+  -b, --body       <text>  - Comment body text                    
+  -p, --parent     <id>    - Parent comment ID for replies
 ```
 
 ##### update
 
 ```
 Usage:   linear issue comment update <commentId>
-Version: 1.8.0                                  
+Version: 1.8.1                                  
 
 Description:
 
@@ -354,15 +369,16 @@ Description:
 
 Options:
 
-  -h, --help          - Show this help.        
-  -b, --body  <text>  - New comment body text
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
+  -b, --body       <text>  - New comment body text
 ```
 
 ##### list
 
 ```
 Usage:   linear issue comment list [issueId]
-Version: 1.8.0                              
+Version: 1.8.1                              
 
 Description:
 
@@ -370,6 +386,7 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.  
-  -j, --json  - Output as JSON
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
+  -j, --json               - Output as JSON
 ```

--- a/skills/linear-cli/references/label.md
+++ b/skills/linear-cli/references/label.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear label
-Version: 1.8.0       
+Version: 1.8.1       
 
 Description:
 
@@ -14,7 +14,8 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.  
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
 
 Commands:
 
@@ -31,7 +32,7 @@ Commands:
 
 ```
 Usage:   linear label list
-Version: 1.8.0            
+Version: 1.8.1            
 
 Description:
 
@@ -52,7 +53,7 @@ Options:
 
 ```
 Usage:   linear label create
-Version: 1.8.0              
+Version: 1.8.1              
 
 Description:
 
@@ -61,6 +62,7 @@ Description:
 Options:
 
   -h, --help                        - Show this help.                                              
+  -w, --workspace    <slug>         - Target workspace (uses credentials)                          
   -n, --name         <name>         - Label name (required)                                        
   -c, --color        <color>        - Color hex code (e.g., #EB5757)                               
   -d, --description  <description>  - Label description                                            
@@ -74,7 +76,7 @@ Options:
 
 ```
 Usage:   linear label delete <nameOrId>
-Version: 1.8.0                         
+Version: 1.8.1                         
 
 Description:
 
@@ -82,7 +84,8 @@ Description:
 
 Options:
 
-  -h, --help              - Show this help.                                 
-  -t, --team   <teamKey>  - Team key to disambiguate labels with same name  
-  -f, --force             - Skip confirmation prompt
+  -h, --help                  - Show this help.                                 
+  -w, --workspace  <slug>     - Target workspace (uses credentials)             
+  -t, --team       <teamKey>  - Team key to disambiguate labels with same name  
+  -f, --force                 - Skip confirmation prompt
 ```

--- a/skills/linear-cli/references/milestone.md
+++ b/skills/linear-cli/references/milestone.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear milestone
-Version: 1.8.0           
+Version: 1.8.1           
 
 Description:
 
@@ -14,7 +14,8 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.  
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
 
 Commands:
 
@@ -33,7 +34,7 @@ Commands:
 
 ```
 Usage:   linear milestone list --project <projectId>
-Version: 1.8.0                                      
+Version: 1.8.1                                      
 
 Description:
 
@@ -41,8 +42,9 @@ Description:
 
 Options:
 
-  -h, --help               - Show this help.            
-  --project   <projectId>  - Project ID       (required)
+  -h, --help                    - Show this help.                                
+  -w, --workspace  <slug>       - Target workspace (uses credentials)            
+  --project        <projectId>  - Project ID                           (required)
 ```
 
 ### view
@@ -51,7 +53,7 @@ Options:
 
 ```
 Usage:   linear milestone view <milestoneId>
-Version: 1.8.0                              
+Version: 1.8.1                              
 
 Description:
 
@@ -59,7 +61,8 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)
 ```
 
 ### create
@@ -68,7 +71,7 @@ Options:
 
 ```
 Usage:   linear milestone create --project <projectId> --name <name>
-Version: 1.8.0                                                      
+Version: 1.8.1                                                      
 
 Description:
 
@@ -76,11 +79,12 @@ Description:
 
 Options:
 
-  -h, --help                    - Show this help.                     
-  --project      <projectId>    - Project ID                (required)
-  --name         <name>         - Milestone name            (required)
-  --description  <description>  - Milestone description               
-  --target-date  <date>         - Target date (YYYY-MM-DD)
+  -h, --help                      - Show this help.                                
+  -w, --workspace  <slug>         - Target workspace (uses credentials)            
+  --project        <projectId>    - Project ID                           (required)
+  --name           <name>         - Milestone name                       (required)
+  --description    <description>  - Milestone description                          
+  --target-date    <date>         - Target date (YYYY-MM-DD)
 ```
 
 ### update
@@ -89,7 +93,7 @@ Options:
 
 ```
 Usage:   linear milestone update <id>
-Version: 1.8.0                       
+Version: 1.8.1                       
 
 Description:
 
@@ -97,11 +101,12 @@ Description:
 
 Options:
 
-  -h, --help                    - Show this help.              
-  --name         <name>         - Milestone name               
-  --description  <description>  - Milestone description        
-  --target-date  <date>         - Target date (YYYY-MM-DD)     
-  --project      <projectId>    - Move to a different project
+  -h, --help                      - Show this help.                      
+  -w, --workspace  <slug>         - Target workspace (uses credentials)  
+  --name           <name>         - Milestone name                       
+  --description    <description>  - Milestone description                
+  --target-date    <date>         - Target date (YYYY-MM-DD)             
+  --project        <projectId>    - Move to a different project
 ```
 
 ### delete
@@ -110,7 +115,7 @@ Options:
 
 ```
 Usage:   linear milestone delete <id>
-Version: 1.8.0                       
+Version: 1.8.1                       
 
 Description:
 
@@ -118,6 +123,7 @@ Description:
 
 Options:
 
-  -h, --help   - Show this help.           
-  -f, --force  - Skip confirmation prompt
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
+  -f, --force              - Skip confirmation prompt
 ```

--- a/skills/linear-cli/references/project-update.md
+++ b/skills/linear-cli/references/project-update.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear project-update
-Version: 1.8.0                
+Version: 1.8.1                
 
 Description:
 
@@ -14,7 +14,8 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.  
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
 
 Commands:
 
@@ -30,7 +31,7 @@ Commands:
 
 ```
 Usage:   linear project-update create <projectId>
-Version: 1.8.0                                   
+Version: 1.8.1                                   
 
 Description:
 
@@ -39,6 +40,7 @@ Description:
 Options:
 
   -h, --help                   - Show this help.                                    
+  -w, --workspace    <slug>    - Target workspace (uses credentials)                
   --body             <body>    - Update content (inline)                            
   --body-file        <path>    - Read content from file                             
   --health           <health>  - Project health status (onTrack, atRisk, offTrack)  
@@ -52,7 +54,7 @@ Options:
 
 ```
 Usage:   linear project-update list <projectId>
-Version: 1.8.0                                 
+Version: 1.8.1                                 
 
 Description:
 
@@ -60,7 +62,8 @@ Description:
 
 Options:
 
-  -h, --help           - Show this help.               
-  --json               - Output as JSON                
-  --limit     <limit>  - Limit results    (Default: 10)
+  -h, --help                - Show this help.                                   
+  -w, --workspace  <slug>   - Target workspace (uses credentials)               
+  --json                    - Output as JSON                                    
+  --limit          <limit>  - Limit results                        (Default: 10)
 ```

--- a/skills/linear-cli/references/project.md
+++ b/skills/linear-cli/references/project.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear project
-Version: 1.8.0         
+Version: 1.8.1         
 
 Description:
 
@@ -14,7 +14,8 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.  
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
 
 Commands:
 
@@ -31,7 +32,7 @@ Commands:
 
 ```
 Usage:   linear project list
-Version: 1.8.0              
+Version: 1.8.1              
 
 Description:
 
@@ -39,12 +40,13 @@ Description:
 
 Options:
 
-  -h, --help             - Show this help.               
-  --team       <team>    - Filter by team key            
-  --all-teams            - Show projects from all teams  
-  --status     <status>  - Filter by status name         
-  -w, --web              - Open in web browser           
-  -a, --app              - Open in Linear.app
+  -h, --help                 - Show this help.                      
+  -w, --workspace  <slug>    - Target workspace (uses credentials)  
+  --team           <team>    - Filter by team key                   
+  --all-teams                - Show projects from all teams         
+  --status         <status>  - Filter by status name                
+  -w, --web                  - Open in web browser                  
+  -a, --app                  - Open in Linear.app
 ```
 
 ### view
@@ -53,7 +55,7 @@ Options:
 
 ```
 Usage:   linear project view <projectId>
-Version: 1.8.0                          
+Version: 1.8.1                          
 
 Description:
 
@@ -61,9 +63,10 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.      
-  -w, --web   - Open in web browser  
-  -a, --app   - Open in Linear.app
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
+  -w, --web                - Open in web browser                  
+  -a, --app                - Open in Linear.app
 ```
 
 ### create
@@ -72,7 +75,7 @@ Options:
 
 ```
 Usage:   linear project create
-Version: 1.8.0                
+Version: 1.8.1                
 
 Description:
 
@@ -81,6 +84,7 @@ Description:
 Options:
 
   -h, --help                        - Show this help.                                                          
+  -w, --workspace    <slug>         - Target workspace (uses credentials)                                      
   -n, --name         <name>         - Project name (required)                                                  
   -d, --description  <description>  - Project description                                                      
   -t, --team         <team>         - Team key (required, can be repeated for multiple teams)                  

--- a/skills/linear-cli/references/schema.md
+++ b/skills/linear-cli/references/schema.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear schema
-Version: 1.8.0        
+Version: 1.8.1        
 
 Description:
 
@@ -14,7 +14,8 @@ Description:
 
 Options:
 
-  -h, --help            - Show this help.                                     
-  --json                - Output as JSON introspection result instead of SDL  
-  -o, --output  <file>  - Write schema to file instead of stdout
+  -h, --help               - Show this help.                                     
+  -w, --workspace  <slug>  - Target workspace (uses credentials)                 
+  --json                   - Output as JSON introspection result instead of SDL  
+  -o, --output     <file>  - Write schema to file instead of stdout
 ```

--- a/skills/linear-cli/references/team.md
+++ b/skills/linear-cli/references/team.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear team
-Version: 1.8.0      
+Version: 1.8.1      
 
 Description:
 
@@ -14,7 +14,8 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.  
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
 
 Commands:
 
@@ -34,7 +35,7 @@ Commands:
 
 ```
 Usage:   linear team create
-Version: 1.8.0             
+Version: 1.8.1             
 
 Description:
 
@@ -43,6 +44,7 @@ Description:
 Options:
 
   -h, --help                        - Show this help.                                          
+  -w, --workspace    <slug>         - Target workspace (uses credentials)                      
   -n, --name         <name>         - Name of the team                                         
   -d, --description  <description>  - Description of the team                                  
   -k, --key          <key>          - Team key (if not provided, will be generated from name)  
@@ -57,7 +59,7 @@ Options:
 
 ```
 Usage:   linear team delete <teamKey>
-Version: 1.8.0                       
+Version: 1.8.1                       
 
 Description:
 
@@ -65,9 +67,10 @@ Description:
 
 Options:
 
-  -h, --help                   - Show this help.                                  
-  --move-issues  <targetTeam>  - Move all issues to another team before deletion  
-  -y, --force                  - Skip confirmation prompt
+  -h, --help                     - Show this help.                                  
+  -w, --workspace  <slug>        - Target workspace (uses credentials)              
+  --move-issues    <targetTeam>  - Move all issues to another team before deletion  
+  -y, --force                    - Skip confirmation prompt
 ```
 
 ### list
@@ -76,7 +79,7 @@ Options:
 
 ```
 Usage:   linear team list
-Version: 1.8.0           
+Version: 1.8.1           
 
 Description:
 
@@ -84,9 +87,10 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.      
-  -w, --web   - Open in web browser  
-  -a, --app   - Open in Linear.app
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
+  -w, --web                - Open in web browser                  
+  -a, --app                - Open in Linear.app
 ```
 
 ### id
@@ -95,7 +99,7 @@ Options:
 
 ```
 Usage:   linear team id
-Version: 1.8.0         
+Version: 1.8.1         
 
 Description:
 
@@ -103,7 +107,8 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)
 ```
 
 ### autolinks
@@ -112,7 +117,7 @@ Options:
 
 ```
 Usage:   linear team autolinks
-Version: 1.8.0                
+Version: 1.8.1                
 
 Description:
 
@@ -120,7 +125,8 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)
 ```
 
 ### members
@@ -129,7 +135,7 @@ Options:
 
 ```
 Usage:   linear team members [teamKey]
-Version: 1.8.0                        
+Version: 1.8.1                        
 
 Description:
 
@@ -137,6 +143,7 @@ Description:
 
 Options:
 
-  -h, --help  - Show this help.           
-  -a, --all   - Include inactive members
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
+  -a, --all                - Include inactive members
 ```

--- a/src/commands/auth/auth-default.ts
+++ b/src/commands/auth/auth-default.ts
@@ -1,0 +1,54 @@
+import { Command } from "@cliffy/command"
+import { Select } from "@cliffy/prompt"
+import {
+  getDefaultWorkspace,
+  getWorkspaces,
+  hasWorkspace,
+  setDefaultWorkspace,
+} from "../../credentials.ts"
+
+export const defaultCommand = new Command()
+  .name("default")
+  .description("Set the default workspace")
+  .arguments("[workspace:string]")
+  .action(async (_options, workspace?: string) => {
+    const workspaces = getWorkspaces()
+
+    if (workspaces.length === 0) {
+      console.error("No workspaces configured")
+      console.error("Run `linear auth login` to add a workspace")
+      Deno.exit(1)
+    }
+
+    if (workspaces.length === 1) {
+      console.log(`Only one workspace configured: ${workspaces[0]}`)
+      return
+    }
+
+    const currentDefault = getDefaultWorkspace()
+
+    // If no workspace specified, prompt to select one
+    if (!workspace) {
+      workspace = await Select.prompt({
+        message: "Select default workspace",
+        options: workspaces.map((ws) => ({
+          name: ws === currentDefault ? `${ws} (current)` : ws,
+          value: ws,
+        })),
+      })
+    }
+
+    if (!hasWorkspace(workspace)) {
+      console.error(`Workspace "${workspace}" not found`)
+      console.error(`Available workspaces: ${workspaces.join(", ")}`)
+      Deno.exit(1)
+    }
+
+    if (workspace === currentDefault) {
+      console.log(`"${workspace}" is already the default workspace`)
+      return
+    }
+
+    await setDefaultWorkspace(workspace)
+    console.log(`Default workspace set to: ${workspace}`)
+  })

--- a/src/commands/auth/auth-list.ts
+++ b/src/commands/auth/auth-list.ts
@@ -1,0 +1,108 @@
+import { Command } from "@cliffy/command"
+import { unicodeWidth } from "@std/cli"
+import { gql } from "../../__codegen__/gql.ts"
+import {
+  getAllCredentials,
+  getDefaultWorkspace,
+  getWorkspaces,
+} from "../../credentials.ts"
+import { padDisplay } from "../../utils/display.ts"
+import { createGraphQLClient } from "../../utils/graphql.ts"
+
+const viewerQuery = gql(`
+  query AuthListViewer {
+    viewer {
+      name
+      email
+      organization {
+        name
+        urlKey
+      }
+    }
+  }
+`)
+
+interface WorkspaceInfo {
+  workspace: string
+  isDefault: boolean
+  orgName?: string
+  userName?: string
+  email?: string
+  error?: string
+}
+
+async function fetchWorkspaceInfo(
+  workspace: string,
+  apiKey: string,
+): Promise<WorkspaceInfo> {
+  const isDefault = getDefaultWorkspace() === workspace
+  const client = createGraphQLClient(apiKey)
+
+  try {
+    const result = await client.request(viewerQuery)
+    return {
+      workspace,
+      isDefault,
+      orgName: result.viewer.organization.name,
+      userName: result.viewer.name,
+      email: result.viewer.email,
+    }
+  } catch {
+    return {
+      workspace,
+      isDefault,
+      error: "invalid credentials",
+    }
+  }
+}
+
+export const listCommand = new Command()
+  .name("list")
+  .description("List configured workspaces")
+  .action(async () => {
+    const workspaces = getWorkspaces()
+
+    if (workspaces.length === 0) {
+      console.log("No workspaces configured")
+      console.log("Run `linear auth login` to add a workspace")
+      return
+    }
+
+    const credentials = getAllCredentials()
+
+    // Fetch info for all workspaces in parallel
+    const infoPromises = workspaces.map((ws) =>
+      fetchWorkspaceInfo(ws, credentials[ws]!)
+    )
+    const infos = await Promise.all(infoPromises)
+
+    // Calculate column widths
+    const workspaceWidth = Math.max(
+      9, // "WORKSPACE" header
+      ...infos.map((i) => unicodeWidth(i.workspace)),
+    )
+    const orgWidth = Math.max(
+      8, // "ORG NAME" header
+      ...infos.map((i) => unicodeWidth(i.orgName ?? i.error ?? "")),
+    )
+
+    // Print header
+    const header = `  ${padDisplay("WORKSPACE", workspaceWidth)} ${
+      padDisplay("ORG NAME", orgWidth)
+    } USER`
+    console.log(`%c${header}`, "text-decoration: underline")
+
+    // Print each workspace
+    for (const info of infos) {
+      const prefix = info.isDefault ? "* " : "  "
+      const ws = padDisplay(info.workspace, workspaceWidth)
+      if (info.error) {
+        const org = padDisplay(info.error, orgWidth)
+        console.log(`${prefix}${ws} %c${org}%c`, "color: red", "")
+      } else {
+        const org = padDisplay(info.orgName ?? "", orgWidth)
+        const user = `${info.userName} <${info.email}>`
+        console.log(`${prefix}${ws} ${org} ${user}`)
+      }
+    }
+  })

--- a/src/commands/auth/auth-login.ts
+++ b/src/commands/auth/auth-login.ts
@@ -1,0 +1,94 @@
+import { Command } from "@cliffy/command"
+import { Secret } from "@cliffy/prompt"
+import { yellow } from "@std/fmt/colors"
+import { gql } from "../../__codegen__/gql.ts"
+import {
+  addCredential,
+  getWorkspaces,
+  hasWorkspace,
+} from "../../credentials.ts"
+import { createGraphQLClient } from "../../utils/graphql.ts"
+
+const viewerQuery = gql(`
+  query AuthLoginViewer {
+    viewer {
+      name
+      email
+      organization {
+        name
+        urlKey
+      }
+    }
+  }
+`)
+
+export const loginCommand = new Command()
+  .name("login")
+  .description("Add a workspace credential")
+  .option("-k, --key <key:string>", "API key (prompted if not provided)")
+  .action(async (options) => {
+    let apiKey = options.key
+
+    if (!apiKey) {
+      apiKey = await Secret.prompt({
+        message: "Enter your Linear API key",
+        hint: "Create one at https://linear.app/settings/api",
+      })
+    }
+
+    if (!apiKey) {
+      console.error("No API key provided")
+      Deno.exit(1)
+    }
+
+    // Validate the API key by querying the API
+    const client = createGraphQLClient(apiKey)
+
+    try {
+      const result = await client.request(viewerQuery)
+      const viewer = result.viewer
+      const org = viewer.organization
+      const workspace = org.urlKey
+
+      const alreadyExists = hasWorkspace(workspace)
+      await addCredential(workspace, apiKey)
+
+      const existingCount = getWorkspaces().length
+
+      if (alreadyExists) {
+        console.log(
+          `Updated credentials for workspace: ${org.name} (${workspace})`,
+        )
+      } else {
+        console.log(`Logged in to workspace: ${org.name} (${workspace})`)
+      }
+      console.log(`  User: ${viewer.name} <${viewer.email}>`)
+
+      if (existingCount === 1) {
+        console.log(`  Set as default workspace`)
+      }
+
+      // Warn if LINEAR_API_KEY is set
+      if (Deno.env.get("LINEAR_API_KEY")) {
+        console.log()
+        console.log(
+          yellow("Warning: LINEAR_API_KEY environment variable is set."),
+        )
+        console.log(yellow("It takes precedence over stored credentials."))
+        console.log(
+          yellow(
+            "Remove it from your shell config to use multi-workspace auth.",
+          ),
+        )
+      }
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("401")) {
+        console.error("Invalid API key")
+      } else if (error instanceof Error) {
+        console.error(`Failed to authenticate: ${error.message}`)
+      } else {
+        console.error("Failed to authenticate")
+      }
+      Deno.exit(1)
+    }
+  })

--- a/src/commands/auth/auth-logout.ts
+++ b/src/commands/auth/auth-logout.ts
@@ -1,0 +1,67 @@
+import { Command } from "@cliffy/command"
+import { Confirm, Select } from "@cliffy/prompt"
+import {
+  getDefaultWorkspace,
+  getWorkspaces,
+  hasWorkspace,
+  removeCredential,
+} from "../../credentials.ts"
+
+export const logoutCommand = new Command()
+  .name("logout")
+  .description("Remove a workspace credential")
+  .arguments("[workspace:string]")
+  .option("-f, --force", "Skip confirmation prompt")
+  .action(async (options, workspace?: string) => {
+    const workspaces = getWorkspaces()
+
+    if (workspaces.length === 0) {
+      console.error("No workspaces configured")
+      Deno.exit(1)
+    }
+
+    // If no workspace specified, prompt to select one
+    if (!workspace) {
+      if (workspaces.length === 1) {
+        workspace = workspaces[0]
+      } else {
+        const defaultWorkspace = getDefaultWorkspace()
+        workspace = await Select.prompt({
+          message: "Select workspace to remove",
+          options: workspaces.map((ws) => ({
+            name: ws === defaultWorkspace ? `${ws} (default)` : ws,
+            value: ws,
+          })),
+        })
+      }
+    }
+
+    if (!hasWorkspace(workspace)) {
+      console.error(`Workspace "${workspace}" not found`)
+      Deno.exit(1)
+    }
+
+    // Confirm removal unless --force is specified
+    if (!options.force) {
+      const confirmed = await Confirm.prompt({
+        message: `Remove credentials for workspace "${workspace}"?`,
+        default: false,
+      })
+
+      if (!confirmed) {
+        console.log("Cancelled")
+        return
+      }
+    }
+
+    await removeCredential(workspace)
+    console.log(`Removed credentials for workspace: ${workspace}`)
+
+    const remaining = getWorkspaces()
+    if (remaining.length > 0) {
+      const newDefault = getDefaultWorkspace()
+      if (newDefault) {
+        console.log(`  Default workspace is now: ${newDefault}`)
+      }
+    }
+  })

--- a/src/commands/auth/auth-token.ts
+++ b/src/commands/auth/auth-token.ts
@@ -1,16 +1,16 @@
 import { Command } from "@cliffy/command"
-import { getOption } from "../../config.ts"
+import { getResolvedApiKey } from "../../utils/graphql.ts"
 
 export const tokenCommand = new Command()
   .name("token")
   .description("Print the configured API token")
   .action(() => {
-    const apiKey = getOption("api_key")
+    const apiKey = getResolvedApiKey()
     if (apiKey) {
       console.log(apiKey)
     } else {
       console.error(
-        "No API token configured. Set LINEAR_API_KEY or configure api_key in .linear.toml",
+        "No API key configured. Set LINEAR_API_KEY, add api_key to .linear.toml, or run `linear auth login`.",
       )
       Deno.exit(1)
     }

--- a/src/commands/auth/auth.ts
+++ b/src/commands/auth/auth.ts
@@ -1,5 +1,9 @@
 import { Command } from "@cliffy/command"
 
+import { defaultCommand } from "./auth-default.ts"
+import { listCommand } from "./auth-list.ts"
+import { loginCommand } from "./auth-login.ts"
+import { logoutCommand } from "./auth-logout.ts"
 import { tokenCommand } from "./auth-token.ts"
 import { whoamiCommand } from "./auth-whoami.ts"
 
@@ -8,5 +12,9 @@ export const authCommand = new Command()
   .action(function () {
     this.showHelp()
   })
+  .command("login", loginCommand)
+  .command("logout", logoutCommand)
+  .command("list", listCommand)
+  .command("default", defaultCommand)
   .command("token", tokenCommand)
   .command("whoami", whoamiCommand)

--- a/src/commands/issue/issue-view.ts
+++ b/src/commands/issue/issue-view.ts
@@ -11,6 +11,7 @@ import { ensureDir } from "@std/fs"
 import { join } from "@std/path"
 import { encodeHex } from "@std/encoding/hex"
 import { getOption } from "../../config.ts"
+import { getResolvedApiKey } from "../../utils/graphql.ts"
 import sanitize from "sanitize-filename"
 import { unified } from "unified"
 import remarkParse from "remark-parse"
@@ -449,7 +450,7 @@ async function downloadImage(
 
   const headers: Record<string, string> = {}
   if (url.includes("uploads.linear.app")) {
-    const apiKey = getOption("api_key")
+    const apiKey = getResolvedApiKey()
     if (apiKey) {
       headers["Authorization"] = apiKey
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -162,3 +162,14 @@ export function getOption<T extends OptionName>(
   }
   return undefined as Options[T]
 }
+
+// CLI workspace set via --workspace flag
+let cliWorkspace: string | undefined
+
+export function setCliWorkspace(workspace: string | undefined) {
+  cliWorkspace = workspace
+}
+
+export function getCliWorkspace(): string | undefined {
+  return cliWorkspace
+}

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -1,0 +1,181 @@
+import { parse, stringify } from "@std/toml"
+import { dirname, join } from "@std/path"
+import { ensureDir } from "@std/fs"
+
+export interface Credentials {
+  default?: string
+  [workspace: string]: string | undefined
+}
+
+let credentials: Credentials = {}
+
+/**
+ * Get the path to the credentials file.
+ * Follows XDG Base Directory Specification on Unix-like systems,
+ * and uses APPDATA on Windows.
+ */
+export function getCredentialsPath(): string | null {
+  if (Deno.build.os === "windows") {
+    const appData = Deno.env.get("APPDATA")
+    if (appData) {
+      return join(appData, "linear", "credentials.toml")
+    }
+  } else {
+    const xdgConfigHome = Deno.env.get("XDG_CONFIG_HOME")
+    const homeDir = Deno.env.get("HOME")
+    if (xdgConfigHome) {
+      return join(xdgConfigHome, "linear", "credentials.toml")
+    } else if (homeDir) {
+      return join(homeDir, ".config", "linear", "credentials.toml")
+    }
+  }
+  return null
+}
+
+/**
+ * Load credentials from the credentials file.
+ */
+export async function loadCredentials(): Promise<Credentials> {
+  const path = getCredentialsPath()
+  if (!path) {
+    return {}
+  }
+
+  try {
+    const file = await Deno.readTextFile(path)
+    credentials = parse(file) as Credentials
+    return credentials
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Save credentials to the credentials file.
+ */
+export async function saveCredentials(creds: Credentials): Promise<void> {
+  const path = getCredentialsPath()
+  if (!path) {
+    throw new Error("Could not determine credentials path")
+  }
+
+  // Ensure the directory exists
+  const dir = dirname(path)
+  await ensureDir(dir)
+
+  // Build a clean object for serialization
+  // Put default first, then workspaces in alphabetical order
+  const ordered: Record<string, string> = {}
+  if (creds.default) {
+    ordered.default = creds.default
+  }
+  const workspaces = Object.keys(creds)
+    .filter((k) => k !== "default")
+    .sort()
+  for (const ws of workspaces) {
+    const value = creds[ws]
+    if (value) {
+      ordered[ws] = value
+    }
+  }
+
+  await Deno.writeTextFile(path, stringify(ordered))
+  credentials = creds
+}
+
+/**
+ * Add or update a credential.
+ * If this is the first workspace, it becomes the default.
+ */
+export async function addCredential(
+  workspace: string,
+  apiKey: string,
+): Promise<void> {
+  const creds = { ...credentials }
+
+  // If this is the first workspace, make it the default
+  const existingWorkspaces = Object.keys(creds).filter((k) => k !== "default")
+  if (existingWorkspaces.length === 0) {
+    creds.default = workspace
+  }
+
+  creds[workspace] = apiKey
+  await saveCredentials(creds)
+}
+
+/**
+ * Remove a credential.
+ * If removing the default, reassign to another workspace or clear.
+ */
+export async function removeCredential(workspace: string): Promise<void> {
+  const creds = { ...credentials }
+  delete creds[workspace]
+
+  // If we removed the default, reassign it
+  if (creds.default === workspace) {
+    const remaining = Object.keys(creds).filter((k) => k !== "default")
+    if (remaining.length > 0) {
+      creds.default = remaining[0]
+    } else {
+      delete creds.default
+    }
+  }
+
+  await saveCredentials(creds)
+}
+
+/**
+ * Set the default workspace.
+ */
+export async function setDefaultWorkspace(workspace: string): Promise<void> {
+  if (!credentials[workspace]) {
+    throw new Error(`Workspace "${workspace}" not found in credentials`)
+  }
+  const creds = { ...credentials }
+  creds.default = workspace
+  await saveCredentials(creds)
+}
+
+/**
+ * Get the API key for a workspace, or the default if not specified.
+ */
+export function getCredentialApiKey(workspace?: string): string | undefined {
+  if (workspace) {
+    return credentials[workspace]
+  }
+  if (credentials.default) {
+    return credentials[credentials.default]
+  }
+  return undefined
+}
+
+/**
+ * Get the current default workspace slug.
+ */
+export function getDefaultWorkspace(): string | undefined {
+  return credentials.default
+}
+
+/**
+ * Get all configured workspaces (excluding 'default' key).
+ */
+export function getWorkspaces(): string[] {
+  return Object.keys(credentials).filter((k) => k !== "default")
+}
+
+/**
+ * Check if a workspace is configured.
+ */
+export function hasWorkspace(workspace: string): boolean {
+  return workspace in credentials && workspace !== "default"
+}
+
+/**
+ * Get all credentials (for listing purposes).
+ */
+export function getAllCredentials(): Credentials {
+  return { ...credentials }
+}
+
+// Load credentials at startup
+await loadCredentials()

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,14 +13,23 @@ import { labelCommand } from "./commands/label/label.ts"
 import { documentCommand } from "./commands/document/document.ts"
 import { configCommand } from "./commands/config.ts"
 import { schemaCommand } from "./commands/schema.ts"
+import { setCliWorkspace } from "./config.ts"
 
-// Import config setup
+// Import config and credentials setup
 import "./config.ts"
+import "./credentials.ts"
 
 await new Command()
   .name("linear")
   .version(denoConfig.version)
   .description("Handy linear commands from the command line")
+  .globalOption(
+    "-w, --workspace <slug:string>",
+    "Target workspace (uses credentials)",
+  )
+  .globalAction((options) => {
+    setCliWorkspace(options.workspace)
+  })
   .action(() => {
     console.log("Use --help to see available commands")
   })

--- a/test/commands/document/__snapshots__/document-create.test.ts.snap
+++ b/test/commands/document/__snapshots__/document-create.test.ts.snap
@@ -69,4 +69,3 @@ stderr:
 "Title is required. Use --title or run with -i for interactive mode.
 "
 `;
-

--- a/test/commands/document/__snapshots__/document-update.test.ts.snap
+++ b/test/commands/document/__snapshots__/document-update.test.ts.snap
@@ -58,4 +58,3 @@ stderr:
 "No update fields provided. Use --title, --content, --content-file, --icon, or --edit.
 "
 `;
-

--- a/test/credentials.test.ts
+++ b/test/credentials.test.ts
@@ -1,0 +1,292 @@
+import { assertEquals } from "@std/assert"
+import { fromFileUrl } from "@std/path"
+
+// Note: Testing the credentials module requires running subprocesses
+// because credentials are loaded at module initialization via top-level await
+
+const credentialsUrl = new URL("../src/credentials.ts", import.meta.url)
+const denoJsonPath = fromFileUrl(new URL("../deno.json", import.meta.url))
+
+async function runWithCredentials(
+  tempDir: string,
+  code: string,
+): Promise<string> {
+  const isWindows = Deno.build.os === "windows"
+  // On Unix, set XDG_CONFIG_HOME to tempDir so credentials go to tempDir/linear/
+  // This overrides HOME-based path and ensures isolation in CI
+  const env: Record<string, string> = isWindows
+    ? { APPDATA: tempDir, SystemRoot: Deno.env.get("SystemRoot") ?? "" }
+    : {
+      HOME: tempDir,
+      XDG_CONFIG_HOME: tempDir,
+      PATH: Deno.env.get("PATH") ?? "",
+    }
+
+  const command = new Deno.Command("deno", {
+    args: [
+      "eval",
+      `--config=${denoJsonPath}`,
+      code,
+    ],
+    cwd: tempDir,
+    env,
+    stdout: "piped",
+    stderr: "piped",
+  })
+
+  const { stdout, stderr } = await command.output()
+  const output = new TextDecoder().decode(stdout).trim()
+  const errorOutput = new TextDecoder().decode(stderr)
+
+  if (errorOutput && !errorOutput.includes("Check")) {
+    console.error("Subprocess stderr:", errorOutput)
+  }
+
+  return output
+}
+
+Deno.test("credentials - getCredentialsPath returns correct path", async () => {
+  const tempDir = await Deno.makeTempDir()
+
+  try {
+    const isWindows = Deno.build.os === "windows"
+    // With XDG_CONFIG_HOME set to tempDir, path is tempDir/linear/credentials.toml
+    const expectedPath = isWindows
+      ? `${tempDir}\\linear\\credentials.toml`
+      : `${tempDir}/linear/credentials.toml`
+
+    const code = `
+      import { getCredentialsPath } from "${credentialsUrl}";
+      console.log(getCredentialsPath());
+    `
+
+    const output = await runWithCredentials(tempDir, code)
+    assertEquals(output, expectedPath)
+  } finally {
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})
+
+Deno.test("credentials - loadCredentials returns empty object when no file", async () => {
+  const tempDir = await Deno.makeTempDir()
+
+  try {
+    const code = `
+      import { loadCredentials } from "${credentialsUrl}";
+      const creds = await loadCredentials();
+      console.log(JSON.stringify(creds));
+    `
+
+    const output = await runWithCredentials(tempDir, code)
+    assertEquals(output, "{}")
+  } finally {
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})
+
+Deno.test("credentials - addCredential creates file and sets default", async () => {
+  const tempDir = await Deno.makeTempDir()
+
+  try {
+    const code = `
+      import { addCredential, getAllCredentials, getDefaultWorkspace } from "${credentialsUrl}";
+      await addCredential("test-workspace", "lin_api_test123");
+      const creds = getAllCredentials();
+      console.log(JSON.stringify({
+        creds,
+        default: getDefaultWorkspace()
+      }));
+    `
+
+    const output = await runWithCredentials(tempDir, code)
+    const result = JSON.parse(output)
+
+    assertEquals(result.default, "test-workspace")
+    assertEquals(result.creds["test-workspace"], "lin_api_test123")
+    assertEquals(result.creds.default, "test-workspace")
+  } finally {
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})
+
+Deno.test("credentials - addCredential preserves existing default", async () => {
+  const tempDir = await Deno.makeTempDir()
+
+  try {
+    const code = `
+      import { addCredential, getDefaultWorkspace } from "${credentialsUrl}";
+      await addCredential("first-workspace", "lin_api_first");
+      await addCredential("second-workspace", "lin_api_second");
+      console.log(getDefaultWorkspace());
+    `
+
+    const output = await runWithCredentials(tempDir, code)
+    assertEquals(output, "first-workspace")
+  } finally {
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})
+
+Deno.test("credentials - removeCredential deletes workspace", async () => {
+  const tempDir = await Deno.makeTempDir()
+
+  try {
+    const code = `
+      import { addCredential, removeCredential, getWorkspaces } from "${credentialsUrl}";
+      await addCredential("workspace-a", "lin_api_a");
+      await addCredential("workspace-b", "lin_api_b");
+      await removeCredential("workspace-a");
+      console.log(JSON.stringify(getWorkspaces()));
+    `
+
+    const output = await runWithCredentials(tempDir, code)
+    const workspaces = JSON.parse(output)
+
+    assertEquals(workspaces, ["workspace-b"])
+  } finally {
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})
+
+Deno.test("credentials - removeCredential reassigns default", async () => {
+  const tempDir = await Deno.makeTempDir()
+
+  try {
+    const code = `
+      import { addCredential, removeCredential, getDefaultWorkspace } from "${credentialsUrl}";
+      await addCredential("workspace-a", "lin_api_a");
+      await addCredential("workspace-b", "lin_api_b");
+      await removeCredential("workspace-a");
+      console.log(getDefaultWorkspace());
+    `
+
+    const output = await runWithCredentials(tempDir, code)
+    assertEquals(output, "workspace-b")
+  } finally {
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})
+
+Deno.test("credentials - setDefaultWorkspace changes default", async () => {
+  const tempDir = await Deno.makeTempDir()
+
+  try {
+    const code = `
+      import { addCredential, setDefaultWorkspace, getDefaultWorkspace } from "${credentialsUrl}";
+      await addCredential("workspace-a", "lin_api_a");
+      await addCredential("workspace-b", "lin_api_b");
+      await setDefaultWorkspace("workspace-b");
+      console.log(getDefaultWorkspace());
+    `
+
+    const output = await runWithCredentials(tempDir, code)
+    assertEquals(output, "workspace-b")
+  } finally {
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})
+
+Deno.test("credentials - getCredentialApiKey returns key for workspace", async () => {
+  const tempDir = await Deno.makeTempDir()
+
+  try {
+    const code = `
+      import { addCredential, getCredentialApiKey } from "${credentialsUrl}";
+      await addCredential("my-workspace", "lin_api_mykey");
+      console.log(getCredentialApiKey("my-workspace"));
+    `
+
+    const output = await runWithCredentials(tempDir, code)
+    assertEquals(output, "lin_api_mykey")
+  } finally {
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})
+
+Deno.test("credentials - getCredentialApiKey returns default when no workspace specified", async () => {
+  const tempDir = await Deno.makeTempDir()
+
+  try {
+    const code = `
+      import { addCredential, getCredentialApiKey } from "${credentialsUrl}";
+      await addCredential("default-workspace", "lin_api_default");
+      console.log(getCredentialApiKey());
+    `
+
+    const output = await runWithCredentials(tempDir, code)
+    assertEquals(output, "lin_api_default")
+  } finally {
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})
+
+Deno.test("credentials - getCredentialApiKey returns undefined for unknown workspace", async () => {
+  const tempDir = await Deno.makeTempDir()
+
+  try {
+    const code = `
+      import { addCredential, getCredentialApiKey } from "${credentialsUrl}";
+      await addCredential("known-workspace", "lin_api_known");
+      console.log(getCredentialApiKey("unknown-workspace") ?? "undefined");
+    `
+
+    const output = await runWithCredentials(tempDir, code)
+    assertEquals(output, "undefined")
+  } finally {
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})
+
+Deno.test("credentials - hasWorkspace returns correct boolean", async () => {
+  const tempDir = await Deno.makeTempDir()
+
+  try {
+    const code = `
+      import { addCredential, hasWorkspace } from "${credentialsUrl}";
+      await addCredential("exists", "lin_api_exists");
+      console.log(JSON.stringify({
+        exists: hasWorkspace("exists"),
+        notExists: hasWorkspace("not-exists")
+      }));
+    `
+
+    const output = await runWithCredentials(tempDir, code)
+    const result = JSON.parse(output)
+
+    assertEquals(result.exists, true)
+    assertEquals(result.notExists, false)
+  } finally {
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})
+
+Deno.test("credentials - loadCredentials reads existing file", async () => {
+  const tempDir = await Deno.makeTempDir()
+
+  try {
+    // With XDG_CONFIG_HOME set to tempDir, credentials are at tempDir/linear/
+    const configDir = `${tempDir}/linear`
+
+    await Deno.mkdir(configDir, { recursive: true })
+    await Deno.writeTextFile(
+      `${configDir}/credentials.toml`,
+      `default = "preexisting"\npreexisting = "lin_api_preexisting"\n`,
+    )
+
+    const code = `
+      import { getAllCredentials, getDefaultWorkspace } from "${credentialsUrl}";
+      console.log(JSON.stringify({
+        default: getDefaultWorkspace(),
+        creds: getAllCredentials()
+      }));
+    `
+
+    const output = await runWithCredentials(tempDir, code)
+    const result = JSON.parse(output)
+
+    assertEquals(result.default, "preexisting")
+    assertEquals(result.creds.preexisting, "lin_api_preexisting")
+  } finally {
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})


### PR DESCRIPTION
Add built-in credential storage for managing multiple Linear workspaces:
- ~/.config/linear/credentials.toml stores API keys by workspace slug
- auth login: add credentials (auto-detects workspace from API)
- auth logout: remove credentials
- auth list: show configured workspaces with org/user info  
- auth default: set the default workspace
- global -w/--workspace flag to target specific workspace

API key precedence: CLI flag > env var > config > workspace flag > project workspace > default