### PR TITLE
docs: add warning about new auth login command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ deno task install
 
 ## setup
 
+> [!WARNING]
+> The `linear auth login` command is new and may have issues. For stable release setup instructions, see the [v1.8.1 README](https://github.com/schpet/linear-cli/blob/v1.8.1/README.md).
+
 1. create an API key at [linear.app/settings/account/security](https://linear.app/settings/account/security)[^1]
 
 2. add the API key to your shell environment:


### PR DESCRIPTION
Add a warning callout in the setup section noting that `linear auth login` is new and may have issues, with a link to the v1.8.1 README for stable setup instructions.