### PR TITLE
fix: error when --workspace flag specifies unknown workspace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,12 @@
 - see [docs/deno-permissions.md](docs/deno-permissions.md) for the full list of files to update when adding new permissions
 - key files: `deno.json` (tasks), `dist-workspace.toml` (release builds), test files
 
+## error handling
+
+- never fail silently - if something goes wrong or a lookup fails, throw an error with a helpful message
+- when user-provided input (flags, args) doesn't match expected values, error immediately with guidance on how to fix it
+- avoid falling back to defaults when explicit user input is invalid; explicit input should either work or error
+
 ## tests
 
 - tests on commands should mirror the directory structure of the src, e.g.

--- a/test/utils/graphql.test.ts
+++ b/test/utils/graphql.test.ts
@@ -1,0 +1,55 @@
+import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert"
+import { setCliWorkspace } from "../../src/config.ts"
+import { getResolvedApiKey } from "../../src/utils/graphql.ts"
+
+Deno.test("getResolvedApiKey - errors when --workspace not found in credentials", () => {
+  // Setup - use a workspace name that definitely doesn't exist
+  Deno.env.delete("LINEAR_API_KEY")
+  setCliWorkspace("nonexistent-workspace-xyz-123")
+
+  try {
+    const error = assertThrows(
+      () => getResolvedApiKey(),
+      Error,
+    )
+    assertStringIncludes(
+      error.message,
+      'Workspace "nonexistent-workspace-xyz-123" not found in credentials',
+    )
+  } finally {
+    // Cleanup
+    setCliWorkspace(undefined)
+  }
+})
+
+Deno.test("getResolvedApiKey - errors when LINEAR_API_KEY and --workspace both set", () => {
+  // Setup
+  Deno.env.set("LINEAR_API_KEY", "test-api-key")
+  setCliWorkspace("test-workspace")
+
+  try {
+    assertThrows(
+      () => getResolvedApiKey(),
+      Error,
+      "Cannot use --workspace flag when LINEAR_API_KEY environment variable is set",
+    )
+  } finally {
+    // Cleanup
+    Deno.env.delete("LINEAR_API_KEY")
+    setCliWorkspace(undefined)
+  }
+})
+
+Deno.test("getResolvedApiKey - returns LINEAR_API_KEY when set without --workspace", () => {
+  // Setup
+  Deno.env.set("LINEAR_API_KEY", "test-api-key")
+  setCliWorkspace(undefined)
+
+  try {
+    const result = getResolvedApiKey()
+    assertEquals(result, "test-api-key")
+  } finally {
+    // Cleanup
+    Deno.env.delete("LINEAR_API_KEY")
+  }
+})


### PR DESCRIPTION
Previously, --workspace would silently fall back to other credential
sources when the specified workspace wasn't found. Now it errors with
a helpful message suggesting `linear auth login` or `linear auth list`.

Also errors when both LINEAR_API_KEY env var and --workspace are set,
since these are conflicting ways to specify credentials.

Added error handling guidelines to CLAUDE.md to prevent silent failures.
