### PR TITLE
feat: show attachments (PRs, commits) in issue view

### DIFF
--- a/src/commands/issue/issue-view.ts
+++ b/src/commands/issue/issue-view.ts
@@ -133,6 +133,18 @@ export const viewCommand = new Command()
         outputLines.push(...renderedHierarchy.split("\n"))
       }
 
+      // Add attachments (PRs, etc.)
+      const attachmentsMarkdown = formatAttachmentsAsMarkdown(
+        issueData.attachments,
+      )
+      if (attachmentsMarkdown) {
+        const renderedAttachments = renderMarkdown(attachmentsMarkdown, {
+          lineWidth: terminalWidth,
+          extensions,
+        })
+        outputLines.push(...renderedAttachments.split("\n"))
+      }
+
       // Add comments if enabled
       if (showComments && issueComments && issueComments.length > 0) {
         outputLines.push("") // Empty line before comments
@@ -159,6 +171,9 @@ export const viewCommand = new Command()
         issueData.parent,
         issueData.children,
       )
+
+      // Add attachments (PRs, etc.)
+      markdown += formatAttachmentsAsMarkdown(issueData.attachments)
 
       if (showComments && issueComments && issueComments.length > 0) {
         markdown += "\n\n## Comments\n\n"
@@ -195,6 +210,32 @@ function formatIssueHierarchyAsMarkdown(
       markdown +=
         `- **${child.identifier}**: ${child.title} _[${child.state.name}]_\n`
     }
+  }
+
+  return markdown
+}
+
+// Helper type for attachment display
+type AttachmentRef = {
+  title: string
+  url: string
+  sourceType?: string | null
+}
+
+// Helper function to format attachments as markdown
+function formatAttachmentsAsMarkdown(
+  attachments: AttachmentRef[] | undefined,
+): string {
+  if (!attachments || attachments.length === 0) {
+    return ""
+  }
+
+  let markdown = `\n\n## Attachments\n\n`
+  for (const attachment of attachments) {
+    const sourceLabel = attachment.sourceType
+      ? ` _[${attachment.sourceType}]_`
+      : ""
+    markdown += `- [${attachment.title}](${attachment.url})${sourceLabel}\n`
   }
 
   return markdown

--- a/src/utils/linear.ts
+++ b/src/utils/linear.ts
@@ -176,6 +176,11 @@ export async function fetchIssueDetails(
     title: string
     state: { name: string; color: string }
   }>
+  attachments?: Array<{
+    title: string
+    url: string
+    sourceType?: string | null
+  }>
   comments?: Array<{
     id: string
     body: string
@@ -217,6 +222,13 @@ export async function fetchIssueDetails(
                 name
                 color
               }
+            }
+          }
+          attachments {
+            nodes {
+              title
+              url
+              sourceType
             }
           }
           comments(first: 50, orderBy: createdAt) {
@@ -271,6 +283,13 @@ export async function fetchIssueDetails(
               }
             }
           }
+          attachments {
+            nodes {
+              title
+              url
+              sourceType
+            }
+          }
         }
       }
     `)
@@ -283,6 +302,7 @@ export async function fetchIssueDetails(
       return {
         ...data.issue,
         children: data.issue.children?.nodes || [],
+        attachments: data.issue.attachments?.nodes || [],
         comments: data.issue.comments?.nodes || [],
       }
     } else {
@@ -291,6 +311,7 @@ export async function fetchIssueDetails(
       return {
         ...data.issue,
         children: data.issue.children?.nodes || [],
+        attachments: data.issue.attachments?.nodes || [],
       }
     }
   } catch (error) {

--- a/test/commands/issue/__snapshots__/issue-describe.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-describe.test.ts.snap
@@ -43,7 +43,7 @@ stderr:
 
 snapshot[`Issue Describe Command - Issue Not Found 1`] = `
 stdout:
-'Error: Issue not found: TEST-999: {"response":{"errors":[{"message":"Issue not found: TEST-999","extensions":{"code":"NOT_FOUND"}}],"status":200,"headers":{}},"request":{"query":"query GetIssueDetails(\$id: String!) {\\\\n  issue(id: \$id) {\\\\n    identifier\\\\n    title\\\\n    description\\\\n    url\\\\n    branchName\\\\n    state {\\\\n      name\\\\n      color\\\\n    }\\\\n    parent {\\\\n      identifier\\\\n      title\\\\n      state {\\\\n        name\\\\n        color\\\\n      }\\\\n    }\\\\n    children {\\\\n      nodes {\\\\n        identifier\\\\n        title\\\\n        state {\\\\n          name\\\\n          color\\\\n        }\\\\n      }\\\\n    }\\\\n  }\\\\n}","variables":{"id":"TEST-999"}}}
+'Error: Issue not found: TEST-999: {"response":{"errors":[{"message":"Issue not found: TEST-999","extensions":{"code":"NOT_FOUND"}}],"status":200,"headers":{}},"request":{"query":"query GetIssueDetails(\$id: String!) {\\\\n  issue(id: \$id) {\\\\n    identifier\\\\n    title\\\\n    description\\\\n    url\\\\n    branchName\\\\n    state {\\\\n      name\\\\n      color\\\\n    }\\\\n    parent {\\\\n      identifier\\\\n      title\\\\n      state {\\\\n        name\\\\n        color\\\\n      }\\\\n    }\\\\n    children {\\\\n      nodes {\\\\n        identifier\\\\n        title\\\\n        state {\\\\n          name\\\\n          color\\\\n        }\\\\n      }\\\\n    }\\\\n    attachments {\\\\n      nodes {\\\\n        title\\\\n        url\\\\n        sourceType\\\\n      }\\\\n    }\\\\n  }\\\\n}","variables":{"id":"TEST-999"}}}
 '
 stderr:
 "✗ Failed to fetch issue details

--- a/test/commands/issue/__snapshots__/issue-view.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-view.test.ts.snap
@@ -97,7 +97,7 @@ stderr:
 
 snapshot[`Issue View Command - Issue Not Found 1`] = `
 stdout:
-'Error: Issue not found: TEST-999: {"response":{"errors":[{"message":"Issue not found: TEST-999","extensions":{"code":"NOT_FOUND"}}],"status":200,"headers":{}},"request":{"query":"query GetIssueDetailsWithComments(\$id: String!) {\\\\n  issue(id: \$id) {\\\\n    identifier\\\\n    title\\\\n    description\\\\n    url\\\\n    branchName\\\\n    state {\\\\n      name\\\\n      color\\\\n    }\\\\n    parent {\\\\n      identifier\\\\n      title\\\\n      state {\\\\n        name\\\\n        color\\\\n      }\\\\n    }\\\\n    children {\\\\n      nodes {\\\\n        identifier\\\\n        title\\\\n        state {\\\\n          name\\\\n          color\\\\n        }\\\\n      }\\\\n    }\\\\n    comments(first: 50, orderBy: createdAt) {\\\\n      nodes {\\\\n        id\\\\n        body\\\\n        createdAt\\\\n        user {\\\\n          name\\\\n          displayName\\\\n        }\\\\n        externalUser {\\\\n          name\\\\n          displayName\\\\n        }\\\\n        parent {\\\\n          id\\\\n        }\\\\n      }\\\\n    }\\\\n  }\\\\n}","variables":{"id":"TEST-999"}}}
+'Error: Issue not found: TEST-999: {"response":{"errors":[{"message":"Issue not found: TEST-999","extensions":{"code":"NOT_FOUND"}}],"status":200,"headers":{}},"request":{"query":"query GetIssueDetailsWithComments(\$id: String!) {\\\\n  issue(id: \$id) {\\\\n    identifier\\\\n    title\\\\n    description\\\\n    url\\\\n    branchName\\\\n    state {\\\\n      name\\\\n      color\\\\n    }\\\\n    parent {\\\\n      identifier\\\\n      title\\\\n      state {\\\\n        name\\\\n        color\\\\n      }\\\\n    }\\\\n    children {\\\\n      nodes {\\\\n        identifier\\\\n        title\\\\n        state {\\\\n          name\\\\n          color\\\\n        }\\\\n      }\\\\n    }\\\\n    attachments {\\\\n      nodes {\\\\n        title\\\\n        url\\\\n        sourceType\\\\n      }\\\\n    }\\\\n    comments(first: 50, orderBy: createdAt) {\\\\n      nodes {\\\\n        id\\\\n        body\\\\n        createdAt\\\\n        user {\\\\n          name\\\\n          displayName\\\\n        }\\\\n        externalUser {\\\\n          name\\\\n          displayName\\\\n        }\\\\n        parent {\\\\n          id\\\\n        }\\\\n      }\\\\n    }\\\\n  }\\\\n}","variables":{"id":"TEST-999"}}}
 '
 stderr:
 "✗ Failed to fetch issue details
@@ -117,7 +117,8 @@ stdout:
     "color": "#f87462"
   },
   "parent": null,
-  "children": []
+  "children": [],
+  "attachments": []
 }
 '
 stderr:
@@ -163,7 +164,8 @@ stdout:
         "id": "comment-1"
       }
     }
-  ]
+  ],
+  "attachments": []
 }
 \`
 stderr:


### PR DESCRIPTION
## Summary
- Adds an Attachments section to `issue view` that displays linked PRs, commits, and other attachments
- Each attachment shows its title as a clickable link and source type (e.g., `github`, `githubCommit`)

## Example output
```
## Attachments

- [Enable control plane RDS infrastructure in prod](https://github.com/...) _[github]_
- [enable control plane RDS infrastructure in prod](https://github.com/...) _[githubCommit]_
```

## Test plan
- [x] Run `linear issue view <issue-with-pr>` and verify attachments are shown
- [x] Verified with real issue that has linked PRs and commits
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)