### PR TITLE
feat: user-friendly error messages with debug mode support

### DIFF
--- a/src/commands/auth/auth-list.ts
+++ b/src/commands/auth/auth-list.ts
@@ -7,6 +7,7 @@ import {
   getWorkspaces,
 } from "../../credentials.ts"
 import { padDisplay } from "../../utils/display.ts"
+import { handleError } from "../../utils/errors.ts"
 import { createGraphQLClient } from "../../utils/graphql.ts"
 
 const viewerQuery = gql(`
@@ -60,49 +61,53 @@ export const listCommand = new Command()
   .name("list")
   .description("List configured workspaces")
   .action(async () => {
-    const workspaces = getWorkspaces()
+    try {
+      const workspaces = getWorkspaces()
 
-    if (workspaces.length === 0) {
-      console.log("No workspaces configured")
-      console.log("Run `linear auth login` to add a workspace")
-      return
-    }
-
-    const credentials = getAllCredentials()
-
-    // Fetch info for all workspaces in parallel
-    const infoPromises = workspaces.map((ws) =>
-      fetchWorkspaceInfo(ws, credentials[ws]!)
-    )
-    const infos = await Promise.all(infoPromises)
-
-    // Calculate column widths
-    const workspaceWidth = Math.max(
-      9, // "WORKSPACE" header
-      ...infos.map((i) => unicodeWidth(i.workspace)),
-    )
-    const orgWidth = Math.max(
-      8, // "ORG NAME" header
-      ...infos.map((i) => unicodeWidth(i.orgName ?? i.error ?? "")),
-    )
-
-    // Print header
-    const header = `  ${padDisplay("WORKSPACE", workspaceWidth)} ${
-      padDisplay("ORG NAME", orgWidth)
-    } USER`
-    console.log(`%c${header}`, "text-decoration: underline")
-
-    // Print each workspace
-    for (const info of infos) {
-      const prefix = info.isDefault ? "* " : "  "
-      const ws = padDisplay(info.workspace, workspaceWidth)
-      if (info.error) {
-        const org = padDisplay(info.error, orgWidth)
-        console.log(`${prefix}${ws} %c${org}%c`, "color: red", "")
-      } else {
-        const org = padDisplay(info.orgName ?? "", orgWidth)
-        const user = `${info.userName} <${info.email}>`
-        console.log(`${prefix}${ws} ${org} ${user}`)
+      if (workspaces.length === 0) {
+        console.log("No workspaces configured")
+        console.log("Run `linear auth login` to add a workspace")
+        return
       }
+
+      const credentials = getAllCredentials()
+
+      // Fetch info for all workspaces in parallel
+      const infoPromises = workspaces.map((ws) =>
+        fetchWorkspaceInfo(ws, credentials[ws]!)
+      )
+      const infos = await Promise.all(infoPromises)
+
+      // Calculate column widths
+      const workspaceWidth = Math.max(
+        9, // "WORKSPACE" header
+        ...infos.map((i) => unicodeWidth(i.workspace)),
+      )
+      const orgWidth = Math.max(
+        8, // "ORG NAME" header
+        ...infos.map((i) => unicodeWidth(i.orgName ?? i.error ?? "")),
+      )
+
+      // Print header
+      const header = `  ${padDisplay("WORKSPACE", workspaceWidth)} ${
+        padDisplay("ORG NAME", orgWidth)
+      } USER`
+      console.log(`%c${header}`, "text-decoration: underline")
+
+      // Print each workspace
+      for (const info of infos) {
+        const prefix = info.isDefault ? "* " : "  "
+        const ws = padDisplay(info.workspace, workspaceWidth)
+        if (info.error) {
+          const org = padDisplay(info.error, orgWidth)
+          console.log(`${prefix}${ws} %c${org}%c`, "color: red", "")
+        } else {
+          const org = padDisplay(info.orgName ?? "", orgWidth)
+          const user = `${info.userName} <${info.email}>`
+          console.log(`${prefix}${ws} ${org} ${user}`)
+        }
+      }
+    } catch (error) {
+      handleError(error, "Failed to list workspaces")
     }
   })

--- a/src/commands/auth/auth-logout.ts
+++ b/src/commands/auth/auth-logout.ts
@@ -6,6 +6,7 @@ import {
   hasWorkspace,
   removeCredential,
 } from "../../credentials.ts"
+import { AuthError, handleError, NotFoundError } from "../../utils/errors.ts"
 
 export const logoutCommand = new Command()
   .name("logout")
@@ -13,55 +14,57 @@ export const logoutCommand = new Command()
   .arguments("[workspace:string]")
   .option("-f, --force", "Skip confirmation prompt")
   .action(async (options, workspace?: string) => {
-    const workspaces = getWorkspaces()
+    try {
+      const workspaces = getWorkspaces()
 
-    if (workspaces.length === 0) {
-      console.error("No workspaces configured")
-      Deno.exit(1)
-    }
+      if (workspaces.length === 0) {
+        throw new AuthError("No workspaces configured")
+      }
 
-    // If no workspace specified, prompt to select one
-    if (!workspace) {
-      if (workspaces.length === 1) {
-        workspace = workspaces[0]
-      } else {
-        const defaultWorkspace = getDefaultWorkspace()
-        workspace = await Select.prompt({
-          message: "Select workspace to remove",
-          options: workspaces.map((ws) => ({
-            name: ws === defaultWorkspace ? `${ws} (default)` : ws,
-            value: ws,
-          })),
+      // If no workspace specified, prompt to select one
+      if (!workspace) {
+        if (workspaces.length === 1) {
+          workspace = workspaces[0]
+        } else {
+          const defaultWorkspace = getDefaultWorkspace()
+          workspace = await Select.prompt({
+            message: "Select workspace to remove",
+            options: workspaces.map((ws) => ({
+              name: ws === defaultWorkspace ? `${ws} (default)` : ws,
+              value: ws,
+            })),
+          })
+        }
+      }
+
+      if (!hasWorkspace(workspace)) {
+        throw new NotFoundError("Workspace", workspace)
+      }
+
+      // Confirm removal unless --force is specified
+      if (!options.force) {
+        const confirmed = await Confirm.prompt({
+          message: `Remove credentials for workspace "${workspace}"?`,
+          default: false,
         })
+
+        if (!confirmed) {
+          console.log("Cancelled")
+          return
+        }
       }
-    }
 
-    if (!hasWorkspace(workspace)) {
-      console.error(`Workspace "${workspace}" not found`)
-      Deno.exit(1)
-    }
+      await removeCredential(workspace)
+      console.log(`Removed credentials for workspace: ${workspace}`)
 
-    // Confirm removal unless --force is specified
-    if (!options.force) {
-      const confirmed = await Confirm.prompt({
-        message: `Remove credentials for workspace "${workspace}"?`,
-        default: false,
-      })
-
-      if (!confirmed) {
-        console.log("Cancelled")
-        return
+      const remaining = getWorkspaces()
+      if (remaining.length > 0) {
+        const newDefault = getDefaultWorkspace()
+        if (newDefault) {
+          console.log(`  Default workspace is now: ${newDefault}`)
+        }
       }
-    }
-
-    await removeCredential(workspace)
-    console.log(`Removed credentials for workspace: ${workspace}`)
-
-    const remaining = getWorkspaces()
-    if (remaining.length > 0) {
-      const newDefault = getDefaultWorkspace()
-      if (newDefault) {
-        console.log(`  Default workspace is now: ${newDefault}`)
-      }
+    } catch (error) {
+      handleError(error, "Failed to logout")
     }
   })

--- a/src/commands/auth/auth-status.ts
+++ b/src/commands/auth/auth-status.ts
@@ -1,5 +1,6 @@
 import { Command } from "@cliffy/command"
 import { gql } from "../../__codegen__/gql.ts"
+import { handleError } from "../../utils/errors.ts"
 import { getGraphQLClient } from "../../utils/graphql.ts"
 
 const viewerQuery = gql(`
@@ -24,23 +25,27 @@ export const statusCommand = new Command()
   .name("status")
   .description("Print information about the authenticated user")
   .action(async () => {
-    const client = getGraphQLClient()
-    const result = await client.request(viewerQuery)
-    const viewer = result.viewer
-    const org = viewer.organization
+    try {
+      const client = getGraphQLClient()
+      const result = await client.request(viewerQuery)
+      const viewer = result.viewer
+      const org = viewer.organization
 
-    console.log(`Workspace: ${org.name}`)
-    console.log(`  Slug: ${org.urlKey}`)
-    console.log(`  URL: https://linear.app/${org.urlKey}`)
+      console.log(`Workspace: ${org.name}`)
+      console.log(`  Slug: ${org.urlKey}`)
+      console.log(`  URL: https://linear.app/${org.urlKey}`)
 
-    console.log(`User: ${viewer.name}`)
-    if (viewer.displayName !== viewer.name) {
-      console.log(`  Display name: ${viewer.displayName}`)
-    }
-    console.log(`  Email: ${viewer.email}`)
-    if (viewer.admin) {
-      console.log(`  Role: admin`)
-    } else if (viewer.guest) {
-      console.log(`  Role: guest`)
+      console.log(`User: ${viewer.name}`)
+      if (viewer.displayName !== viewer.name) {
+        console.log(`  Display name: ${viewer.displayName}`)
+      }
+      console.log(`  Email: ${viewer.email}`)
+      if (viewer.admin) {
+        console.log(`  Role: admin`)
+      } else if (viewer.guest) {
+        console.log(`  Role: guest`)
+      }
+    } catch (error) {
+      handleError(error, "Failed to get auth status")
     }
   })

--- a/src/commands/auth/auth-token.ts
+++ b/src/commands/auth/auth-token.ts
@@ -1,17 +1,22 @@
 import { Command } from "@cliffy/command"
+import { AuthError, handleError } from "../../utils/errors.ts"
 import { getResolvedApiKey } from "../../utils/graphql.ts"
 
 export const tokenCommand = new Command()
   .name("token")
   .description("Print the configured API token")
   .action(() => {
-    const apiKey = getResolvedApiKey()
-    if (apiKey) {
-      console.log(apiKey)
-    } else {
-      console.error(
-        "No API key configured. Set LINEAR_API_KEY, add api_key to .linear.toml, or run `linear auth login`.",
-      )
-      Deno.exit(1)
+    try {
+      const apiKey = getResolvedApiKey()
+      if (apiKey) {
+        console.log(apiKey)
+      } else {
+        throw new AuthError("No API key configured", {
+          suggestion:
+            "Set LINEAR_API_KEY, add api_key to .linear.toml, or run `linear auth login`.",
+        })
+      }
+    } catch (error) {
+      handleError(error, "Failed to get API token")
     }
   })

--- a/src/commands/auth/auth-whoami.ts
+++ b/src/commands/auth/auth-whoami.ts
@@ -1,5 +1,6 @@
 import { Command } from "@cliffy/command"
 import { gql } from "../../__codegen__/gql.ts"
+import { handleError } from "../../utils/errors.ts"
 import { getGraphQLClient } from "../../utils/graphql.ts"
 
 const viewerQuery = gql(`
@@ -24,23 +25,27 @@ export const whoamiCommand = new Command()
   .name("whoami")
   .description("Print information about the authenticated user")
   .action(async () => {
-    const client = getGraphQLClient()
-    const result = await client.request(viewerQuery)
-    const viewer = result.viewer
-    const org = viewer.organization
+    try {
+      const client = getGraphQLClient()
+      const result = await client.request(viewerQuery)
+      const viewer = result.viewer
+      const org = viewer.organization
 
-    console.log(`Workspace: ${org.name}`)
-    console.log(`  Slug: ${org.urlKey}`)
-    console.log(`  URL: https://linear.app/${org.urlKey}`)
+      console.log(`Workspace: ${org.name}`)
+      console.log(`  Slug: ${org.urlKey}`)
+      console.log(`  URL: https://linear.app/${org.urlKey}`)
 
-    console.log(`User: ${viewer.name}`)
-    if (viewer.displayName !== viewer.name) {
-      console.log(`  Display name: ${viewer.displayName}`)
-    }
-    console.log(`  Email: ${viewer.email}`)
-    if (viewer.admin) {
-      console.log(`  Role: admin`)
-    } else if (viewer.guest) {
-      console.log(`  Role: guest`)
+      console.log(`User: ${viewer.name}`)
+      if (viewer.displayName !== viewer.name) {
+        console.log(`  Display name: ${viewer.displayName}`)
+      }
+      console.log(`  Email: ${viewer.email}`)
+      if (viewer.admin) {
+        console.log(`  Role: admin`)
+      } else if (viewer.guest) {
+        console.log(`  Role: guest`)
+      }
+    } catch (error) {
+      handleError(error, "Failed to get user info")
     }
   })

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -5,6 +5,7 @@ import { gql } from "../__codegen__/gql.ts"
 import { getGraphQLClient } from "../utils/graphql.ts"
 import { getDefaultWorkspace, getWorkspaces } from "../credentials.ts"
 import { getCliWorkspace, getOption, setCliWorkspace } from "../config.ts"
+import { AuthError, handleError, NotFoundError } from "../utils/errors.ts"
 
 const configQuery = gql(`
   query Config {
@@ -27,7 +28,8 @@ export const configCommand = new Command()
   .name("config")
   .description("Interactively generate .linear.toml configuration")
   .action(async () => {
-    console.log(`
+    try {
+      console.log(`
 ██      ██ ███    ██ ███████  █████  ██████      ██████ ██      ██
 ██      ██ ████   ██ ██      ██   ██ ██   ██    ██      ██      ██
 ██      ██ ██ ██  ██ █████   ███████ ██████     ██      ██      ██
@@ -35,102 +37,101 @@ export const configCommand = new Command()
 ███████ ██ ██   ████ ███████ ██   ██ ██   ██     ██████ ███████ ██
 `)
 
-    // Check for explicit API key sources (env var, config, or --workspace flag)
-    const hasExplicitApiKey = Deno.env.get("LINEAR_API_KEY") ||
-      getOption("api_key") ||
-      getCliWorkspace()
+      // Check for explicit API key sources (env var, config, or --workspace flag)
+      const hasExplicitApiKey = Deno.env.get("LINEAR_API_KEY") ||
+        getOption("api_key") ||
+        getCliWorkspace()
 
-    if (!hasExplicitApiKey) {
-      const workspaces = getWorkspaces()
-      if (workspaces.length === 0) {
-        console.error("No authentication configured.")
-        console.error("Run `linear auth login` to add a workspace.")
-        Deno.exit(1)
+      if (!hasExplicitApiKey) {
+        const workspaces = getWorkspaces()
+        if (workspaces.length === 0) {
+          throw new AuthError("No authentication configured", {
+            suggestion: "Run `linear auth login` to add a workspace.",
+          })
+        }
+
+        if (workspaces.length === 1) {
+          // Single workspace - use automatically
+          setCliWorkspace(workspaces[0])
+        } else {
+          // Multiple workspaces - prompt to select
+          const defaultWorkspace = getDefaultWorkspace()
+          const selected = await Select.prompt({
+            message: "Select workspace:",
+            options: workspaces.map((ws) => ({
+              name: ws + (ws === defaultWorkspace ? " (default)" : ""),
+              value: ws,
+            })),
+            default: defaultWorkspace,
+          })
+          setCliWorkspace(selected)
+        }
       }
 
-      if (workspaces.length === 1) {
-        // Single workspace - use automatically
-        setCliWorkspace(workspaces[0])
-      } else {
-        // Multiple workspaces - prompt to select
-        const defaultWorkspace = getDefaultWorkspace()
-        const selected = await Select.prompt({
-          message: "Select workspace:",
-          options: workspaces.map((ws) => ({
-            name: ws + (ws === defaultWorkspace ? " (default)" : ""),
-            value: ws,
-          })),
-          default: defaultWorkspace,
-        })
-        setCliWorkspace(selected)
+      const client = getGraphQLClient()
+      const result = await client.request(configQuery)
+      const workspace = result.viewer.organization.urlKey
+      const teams = result.teams.nodes
+      // Sort teams alphabetically by name (case insensitive)
+      teams.sort((a, b) =>
+        a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+      )
+
+      interface Team {
+        id: string
+        key: string
+        name: string
       }
-    }
 
-    const client = getGraphQLClient()
-    const result = await client.request(configQuery)
-    const workspace = result.viewer.organization.urlKey
-    const teams = result.teams.nodes
-    // Sort teams alphabetically by name (case insensitive)
-    teams.sort((a, b) =>
-      a.name.toLowerCase().localeCompare(b.name.toLowerCase())
-    )
+      const selectedTeamId = await Select.prompt({
+        message: "Select a team:",
+        search: true,
+        searchLabel: "Search teams",
+        options: teams.map((team) => ({
+          name: `${team.name} (${team.key})`,
+          value: team.id,
+        })),
+      })
 
-    interface Team {
-      id: string
-      key: string
-      name: string
-    }
+      const team = teams.find((t) => t.id === selectedTeamId)
 
-    const selectedTeamId = await Select.prompt({
-      message: "Select a team:",
-      search: true,
-      searchLabel: "Search teams",
-      options: teams.map((team) => ({
-        name: `${team.name} (${team.key})`,
-        value: team.id,
-      })),
-    })
+      if (!team) {
+        throw new NotFoundError("Team", selectedTeamId)
+      }
 
-    const team = teams.find((t) => t.id === selectedTeamId)
+      const responses = await prompt([
+        {
+          name: "sort",
+          message: "Select sort order:",
+          type: Select,
+          options: [
+            { name: "manual", value: "manual" },
+            { name: "priority", value: "priority" },
+          ],
+        },
+      ])
+      const teamKey = team.key
+      const sortChoice = responses.sort
 
-    if (!team) {
-      console.error(`Could not find team: ${selectedTeamId}`)
-      Deno.exit(1)
-    }
-
-    const responses = await prompt([
-      {
-        name: "sort",
-        message: "Select sort order:",
-        type: Select,
-        options: [
-          { name: "manual", value: "manual" },
-          { name: "priority", value: "priority" },
-        ],
-      },
-    ])
-    const teamKey = team.key
-    const sortChoice = responses.sort
-
-    // Determine file path for .linear.toml: prefer git root .config dir, then git root, then cwd.
-    let filePath: string
-    try {
-      const gitRootProcess = await new Deno.Command("git", {
-        args: ["rev-parse", "--show-toplevel"],
-      }).output()
-      const gitRoot = new TextDecoder().decode(gitRootProcess.stdout).trim()
-      const configDir = join(gitRoot, ".config")
+      // Determine file path for .linear.toml: prefer git root .config dir, then git root, then cwd.
+      let filePath: string
       try {
-        await Deno.stat(configDir)
-        filePath = join(configDir, "linear.toml")
+        const gitRootProcess = await new Deno.Command("git", {
+          args: ["rev-parse", "--show-toplevel"],
+        }).output()
+        const gitRoot = new TextDecoder().decode(gitRootProcess.stdout).trim()
+        const configDir = join(gitRoot, ".config")
+        try {
+          await Deno.stat(configDir)
+          filePath = join(configDir, "linear.toml")
+        } catch {
+          filePath = join(gitRoot, ".linear.toml")
+        }
       } catch {
-        filePath = join(gitRoot, ".linear.toml")
+        filePath = "./.linear.toml"
       }
-    } catch {
-      filePath = "./.linear.toml"
-    }
 
-    const tomlContent = `# linear cli
+      const tomlContent = `# linear cli
 # https://github.com/schpet/linear-cli
 
 workspace = "${workspace}"
@@ -138,6 +139,9 @@ team_id = "${teamKey}"
 issue_sort = "${sortChoice}"
 `
 
-    await Deno.writeTextFile(filePath, tomlContent)
-    console.log("Configuration written to", filePath)
+      await Deno.writeTextFile(filePath, tomlContent)
+      console.log("Configuration written to", filePath)
+    } catch (error) {
+      handleError(error, "Failed to generate configuration")
+    }
   })

--- a/src/commands/document/document-list.ts
+++ b/src/commands/document/document-list.ts
@@ -3,6 +3,7 @@ import { gql } from "../../__codegen__/gql.ts"
 import { getGraphQLClient } from "../../utils/graphql.ts"
 import { getTimeAgo, padDisplay } from "../../utils/display.ts"
 import { shouldShowSpinner } from "../../utils/hyperlink.ts"
+import { handleError } from "../../utils/errors.ts"
 
 const ListDocuments = gql(`
   query ListDocuments($filter: DocumentFilter, $first: Int) {
@@ -161,7 +162,6 @@ export const listCommand = new Command()
       }
     } catch (error) {
       spinner?.stop()
-      console.error("Failed to fetch documents:", error)
-      Deno.exit(1)
+      handleError(error, "Failed to list documents")
     }
   })

--- a/src/commands/initiative-update/initiative-update-list.ts
+++ b/src/commands/initiative-update/initiative-update-list.ts
@@ -1,11 +1,12 @@
 import { Command } from "@cliffy/command"
 import { gql } from "../../__codegen__/gql.ts"
-import { getGraphQLClient } from "../../utils/graphql.ts"
 import {
   formatRelativeTime,
   padDisplay,
   truncateText,
 } from "../../utils/display.ts"
+import { handleError, NotFoundError } from "../../utils/errors.ts"
+import { getGraphQLClient } from "../../utils/graphql.ts"
 import { shouldShowSpinner } from "../../utils/hyperlink.ts"
 
 /**
@@ -103,8 +104,7 @@ export const listCommand = new Command()
       const resolvedId = await resolveInitiativeId(client, initiativeId)
       if (!resolvedId) {
         spinner?.stop()
-        console.error(`Initiative not found: ${initiativeId}`)
-        Deno.exit(1)
+        throw new NotFoundError("Initiative", initiativeId)
       }
 
       const listQuery = gql(`
@@ -137,8 +137,7 @@ export const listCommand = new Command()
 
       const initiative = result.initiative
       if (!initiative) {
-        console.error(`Initiative not found: ${initiativeId}`)
-        Deno.exit(1)
+        throw new NotFoundError("Initiative", initiativeId)
       }
 
       const updates = initiative.initiativeUpdates?.nodes || []
@@ -260,7 +259,6 @@ export const listCommand = new Command()
       }
     } catch (error) {
       spinner?.stop()
-      console.error("Failed to fetch initiative updates:", error)
-      Deno.exit(1)
+      handleError(error, "Failed to fetch initiative updates")
     }
   })

--- a/src/commands/initiative/initiative-view.ts
+++ b/src/commands/initiative/initiative-view.ts
@@ -5,6 +5,7 @@ import { gql } from "../../__codegen__/gql.ts"
 import { getGraphQLClient } from "../../utils/graphql.ts"
 import { formatRelativeTime } from "../../utils/display.ts"
 import { shouldShowSpinner } from "../../utils/hyperlink.ts"
+import { handleError, NotFoundError } from "../../utils/errors.ts"
 
 const GetInitiativeDetails = gql(`
   query GetInitiativeDetails($id: String!) {
@@ -76,8 +77,7 @@ export const viewCommand = new Command()
     // Resolve initiative ID (can be UUID, slug, or name)
     const resolvedId = await resolveInitiativeId(client, initiativeId)
     if (!resolvedId) {
-      console.error(`Initiative not found: ${initiativeId}`)
-      Deno.exit(1)
+      throw new NotFoundError("Initiative", initiativeId)
     }
 
     // Handle open in browser/app
@@ -88,8 +88,7 @@ export const viewCommand = new Command()
       })
       const initiative = result.initiative
       if (!initiative?.url) {
-        console.error(`Initiative not found: ${initiativeId}`)
-        Deno.exit(1)
+        throw new NotFoundError("Initiative", initiativeId)
       }
 
       const destination = app ? "Linear.app" : "web browser"
@@ -111,8 +110,7 @@ export const viewCommand = new Command()
 
       const initiative = result.initiative
       if (!initiative) {
-        console.error(`Initiative with ID "${initiativeId}" not found.`)
-        Deno.exit(1)
+        throw new NotFoundError("Initiative", initiativeId)
       }
 
       // JSON output
@@ -273,8 +271,7 @@ export const viewCommand = new Command()
       }
     } catch (error) {
       spinner?.stop()
-      console.error("Failed to fetch initiative details:", error)
-      Deno.exit(1)
+      handleError(error, "Failed to fetch initiative details")
     }
   })
 

--- a/src/commands/issue/issue-comment-list.ts
+++ b/src/commands/issue/issue-comment-list.ts
@@ -2,9 +2,9 @@ import { Command } from "@cliffy/command"
 import { gql } from "../../__codegen__/gql.ts"
 import { getGraphQLClient } from "../../utils/graphql.ts"
 import { getIssueIdentifier } from "../../utils/linear.ts"
-import { getNoIssueFoundMessage } from "../../utils/vcs.ts"
 import { formatRelativeTime } from "../../utils/display.ts"
 import { bold } from "@std/fmt/colors"
+import { handleError, ValidationError } from "../../utils/errors.ts"
 
 export const commentListCommand = new Command()
   .name("list")
@@ -17,8 +17,10 @@ export const commentListCommand = new Command()
     try {
       const resolvedIdentifier = await getIssueIdentifier(issueId)
       if (!resolvedIdentifier) {
-        console.error(getNoIssueFoundMessage())
-        Deno.exit(1)
+        throw new ValidationError(
+          "Could not determine issue ID",
+          { suggestion: "Please provide an issue ID like 'ENG-123'." },
+        )
       }
 
       const query = gql(`
@@ -138,7 +140,6 @@ export const commentListCommand = new Command()
         console.log("")
       }
     } catch (error) {
-      console.error("✗ Failed to list comments", error)
-      Deno.exit(1)
+      handleError(error, "Failed to list comments")
     }
   })

--- a/src/commands/issue/issue-comment-update.ts
+++ b/src/commands/issue/issue-comment-update.ts
@@ -2,6 +2,7 @@ import { Command } from "@cliffy/command"
 import { Input } from "@cliffy/prompt"
 import { gql } from "../../__codegen__/gql.ts"
 import { getGraphQLClient } from "../../utils/graphql.ts"
+import { CliError, handleError, ValidationError } from "../../utils/errors.ts"
 
 export const commentUpdateCommand = new Command()
   .name("update")
@@ -38,8 +39,7 @@ export const commentUpdateCommand = new Command()
         })
 
         if (!newBody.trim()) {
-          console.error("Comment body cannot be empty")
-          Deno.exit(1)
+          throw new ValidationError("Comment body cannot be empty")
         }
       }
 
@@ -70,18 +70,17 @@ export const commentUpdateCommand = new Command()
       })
 
       if (!data.commentUpdate.success) {
-        throw new Error("Failed to update comment")
+        throw new CliError("Failed to update comment")
       }
 
       const comment = data.commentUpdate.comment
       if (!comment) {
-        throw new Error("Comment update failed - no comment returned")
+        throw new CliError("Comment update failed - no comment returned")
       }
 
       console.log("✓ Comment updated")
       console.log(comment.url)
     } catch (error) {
-      console.error("✗ Failed to update comment", error)
-      Deno.exit(1)
+      handleError(error, "Failed to update comment")
     }
   })

--- a/src/commands/issue/issue-commits.ts
+++ b/src/commands/issue/issue-commits.ts
@@ -1,75 +1,86 @@
 import { Command } from "@cliffy/command"
-import { isClientError, logClientError } from "../../utils/graphql.ts"
 import { getIssueId, getIssueIdentifier } from "../../utils/linear.ts"
-import { getNoIssueFoundMessage, getVcs } from "../../utils/vcs.ts"
+import { getVcs } from "../../utils/vcs.ts"
+import {
+  handleError,
+  isClientError,
+  isNotFoundError,
+  NotFoundError,
+  ValidationError,
+} from "../../utils/errors.ts"
 
 export const commitsCommand = new Command()
   .name("commits")
   .description("Show all commits for a Linear issue (jj only)")
   .arguments("[issueId:string]")
   .action(async (_options, issueId) => {
-    const vcs = getVcs()
-
-    if (vcs !== "jj") {
-      console.error("✗ commits is only supported with jj-vcs")
-      Deno.exit(1)
-    }
-
-    const resolvedId = await getIssueIdentifier(issueId)
-    if (!resolvedId) {
-      console.error(getNoIssueFoundMessage())
-      Deno.exit(1)
-    }
-
-    // Verify the issue exists in Linear
-    let linearIssueId: string | undefined
     try {
-      linearIssueId = await getIssueId(resolvedId)
-    } catch (error) {
-      if (isClientError(error)) {
-        logClientError(error)
-        Deno.exit(1)
+      const vcs = getVcs()
+
+      if (vcs !== "jj") {
+        throw new ValidationError(
+          "commits is only supported with jj-vcs",
+          { suggestion: "This command requires jujutsu (jj) version control." },
+        )
       }
-      throw error
+
+      const resolvedId = await getIssueIdentifier(issueId)
+      if (!resolvedId) {
+        throw new ValidationError(
+          "Could not determine issue ID",
+          { suggestion: "Please provide an issue ID like 'ENG-123'." },
+        )
+      }
+
+      // Verify the issue exists in Linear
+      let linearIssueId: string | undefined
+      try {
+        linearIssueId = await getIssueId(resolvedId)
+      } catch (error) {
+        if (isClientError(error) && isNotFoundError(error)) {
+          throw new NotFoundError("Issue", resolvedId)
+        }
+        throw error
+      }
+      if (!linearIssueId) {
+        throw new NotFoundError("Issue", resolvedId)
+      }
+
+      // Build the revset to find all commits with this Linear issue
+      const revset = `description(regex:"(?m)^Linear-issue:.*${resolvedId}")`
+
+      // First check if any commits exist
+      const checkProcess = new Deno.Command("jj", {
+        args: ["log", "-r", revset, "-T", "commit_id", "--no-graph"],
+        stdout: "piped",
+        stderr: "piped",
+      })
+      const checkResult = await checkProcess.output()
+      const commitIds = new TextDecoder().decode(checkResult.stdout).trim()
+
+      if (!commitIds) {
+        throw new NotFoundError("Commits", resolvedId)
+      }
+
+      // Show the commits with full details
+      const process = new Deno.Command("jj", {
+        args: [
+          "log",
+          "-r",
+          revset,
+          "-p",
+          "--git",
+          "--no-graph",
+          "-T",
+          "builtin_log_compact_full_description",
+        ],
+        stdout: "inherit",
+        stderr: "inherit",
+      })
+
+      const { code } = await process.output()
+      Deno.exit(code)
+    } catch (error) {
+      handleError(error, "Failed to show commits")
     }
-    if (!linearIssueId) {
-      console.error(`✗ issue not found: ${resolvedId}`)
-      Deno.exit(1)
-    }
-
-    // Build the revset to find all commits with this Linear issue
-    const revset = `description(regex:"(?m)^Linear-issue:.*${resolvedId}")`
-
-    // First check if any commits exist
-    const checkProcess = new Deno.Command("jj", {
-      args: ["log", "-r", revset, "-T", "commit_id", "--no-graph"],
-      stdout: "piped",
-      stderr: "piped",
-    })
-    const checkResult = await checkProcess.output()
-    const commitIds = new TextDecoder().decode(checkResult.stdout).trim()
-
-    if (!commitIds) {
-      console.error(`✗ no commits found for ${resolvedId}`)
-      Deno.exit(1)
-    }
-
-    // Show the commits with full details
-    const process = new Deno.Command("jj", {
-      args: [
-        "log",
-        "-r",
-        revset,
-        "-p",
-        "--git",
-        "--no-graph",
-        "-T",
-        "builtin_log_compact_full_description",
-      ],
-      stdout: "inherit",
-      stderr: "inherit",
-    })
-
-    const { code } = await process.output()
-    Deno.exit(code)
   })

--- a/src/commands/issue/issue-id.ts
+++ b/src/commands/issue/issue-id.ts
@@ -1,16 +1,25 @@
 import { Command } from "@cliffy/command"
 import { getIssueIdentifier } from "../../utils/linear.ts"
-import { getNoIssueFoundMessage } from "../../utils/vcs.ts"
+import { handleError, ValidationError } from "../../utils/errors.ts"
 
 export const idCommand = new Command()
   .name("id")
   .description("Print the issue based on the current git branch")
   .action(async (_) => {
-    const resolvedId = await getIssueIdentifier()
-    if (resolvedId) {
-      console.log(resolvedId)
-    } else {
-      console.error(getNoIssueFoundMessage())
-      Deno.exit(1)
+    try {
+      const resolvedId = await getIssueIdentifier()
+      if (resolvedId) {
+        console.log(resolvedId)
+      } else {
+        throw new ValidationError(
+          "Could not determine issue ID",
+          {
+            suggestion:
+              "Please provide an issue ID or run from a branch with an issue identifier.",
+          },
+        )
+      }
+    } catch (error) {
+      handleError(error, "Failed to get issue ID")
     }
   })

--- a/src/commands/issue/issue-title.ts
+++ b/src/commands/issue/issue-title.ts
@@ -1,17 +1,23 @@
 import { Command } from "@cliffy/command"
 import { fetchIssueDetails, getIssueIdentifier } from "../../utils/linear.ts"
-import { getNoIssueFoundMessage } from "../../utils/vcs.ts"
+import { handleError, ValidationError } from "../../utils/errors.ts"
 
 export const titleCommand = new Command()
   .name("title")
   .description("Print the issue title")
   .arguments("[issueId:string]")
   .action(async (_, issueId) => {
-    const resolvedId = await getIssueIdentifier(issueId)
-    if (!resolvedId) {
-      console.error(getNoIssueFoundMessage())
-      Deno.exit(1)
+    try {
+      const resolvedId = await getIssueIdentifier(issueId)
+      if (!resolvedId) {
+        throw new ValidationError(
+          "Could not determine issue ID",
+          { suggestion: "Please provide an issue ID like 'ENG-123'." },
+        )
+      }
+      const { title } = await fetchIssueDetails(resolvedId, false)
+      console.log(title)
+    } catch (error) {
+      handleError(error, "Failed to get issue title")
     }
-    const { title } = await fetchIssueDetails(resolvedId, false)
-    console.log(title)
   })

--- a/src/commands/issue/issue-url.ts
+++ b/src/commands/issue/issue-url.ts
@@ -1,17 +1,23 @@
 import { Command } from "@cliffy/command"
 import { fetchIssueDetails, getIssueIdentifier } from "../../utils/linear.ts"
-import { getNoIssueFoundMessage } from "../../utils/vcs.ts"
+import { handleError, ValidationError } from "../../utils/errors.ts"
 
 export const urlCommand = new Command()
   .name("url")
   .description("Print the issue URL")
   .arguments("[issueId:string]")
   .action(async (_, issueId) => {
-    const resolvedId = await getIssueIdentifier(issueId)
-    if (!resolvedId) {
-      console.error(getNoIssueFoundMessage())
-      Deno.exit(1)
+    try {
+      const resolvedId = await getIssueIdentifier(issueId)
+      if (!resolvedId) {
+        throw new ValidationError(
+          "Could not determine issue ID",
+          { suggestion: "Please provide an issue ID like 'ENG-123'." },
+        )
+      }
+      const { url } = await fetchIssueDetails(resolvedId, false)
+      console.log(url)
+    } catch (error) {
+      handleError(error, "Failed to get issue URL")
     }
-    const { url } = await fetchIssueDetails(resolvedId, false)
-    console.log(url)
   })

--- a/src/commands/label/label-create.ts
+++ b/src/commands/label/label-create.ts
@@ -4,6 +4,12 @@ import { gql } from "../../__codegen__/gql.ts"
 import { getGraphQLClient } from "../../utils/graphql.ts"
 import { getAllTeams, getTeamIdByKey, getTeamKey } from "../../utils/linear.ts"
 import { shouldShowSpinner } from "../../utils/hyperlink.ts"
+import {
+  CliError,
+  handleError,
+  NotFoundError,
+  ValidationError,
+} from "../../utils/errors.ts"
 
 const CreateIssueLabel = gql(`
   mutation CreateIssueLabel($input: IssueLabelCreateInput!) {
@@ -55,171 +61,174 @@ export const createCommand = new Command()
     "Interactive mode (default if no flags provided)",
   )
   .action(async (options) => {
-    const {
-      name: providedName,
-      color: providedColor,
-      description: providedDescription,
-      team: providedTeam,
-      interactive: interactiveFlag,
-    } = options
+    try {
+      const {
+        name: providedName,
+        color: providedColor,
+        description: providedDescription,
+        team: providedTeam,
+        interactive: interactiveFlag,
+      } = options
 
-    const client = getGraphQLClient()
+      const client = getGraphQLClient()
 
-    let name = providedName
-    let color = providedColor
-    let description = providedDescription
-    let teamKey = providedTeam
+      let name = providedName
+      let color = providedColor
+      let description = providedDescription
+      let teamKey = providedTeam
 
-    // Determine if we should run in interactive mode
-    const noFlagsProvided = !name
-    const isInteractive = (noFlagsProvided || interactiveFlag) &&
-      Deno.stdout.isTerminal()
+      // Determine if we should run in interactive mode
+      const noFlagsProvided = !name
+      const isInteractive = (noFlagsProvided || interactiveFlag) &&
+        Deno.stdout.isTerminal()
 
-    if (isInteractive) {
-      console.log("\nCreate a new label\n")
+      if (isInteractive) {
+        console.log("\nCreate a new label\n")
 
-      // Name (required)
-      if (!name) {
-        name = await Input.prompt({
-          message: "Label name:",
-          minLength: 1,
-        })
-      }
-
-      // Color selection
-      if (!color) {
-        const colorOptions = [
-          ...DEFAULT_COLORS.map((c) => ({
-            name: `${c.name} (${c.value})`,
-            value: c.value,
-          })),
-          { name: "Custom color", value: "custom" },
-        ]
-
-        const selectedColor = await Select.prompt({
-          message: "Color:",
-          options: colorOptions,
-          default: DEFAULT_COLORS[6].value, // Indigo
-        })
-
-        if (selectedColor === "custom") {
-          color = await Input.prompt({
-            message: "Enter hex color (e.g., #FF5733):",
-            validate: (value) => {
-              if (!/^#[0-9A-Fa-f]{6}$/.test(value)) {
-                return "Please enter a valid hex color (e.g., #FF5733)"
-              }
-              return true
-            },
+        // Name (required)
+        if (!name) {
+          name = await Input.prompt({
+            message: "Label name:",
+            minLength: 1,
           })
-        } else {
-          color = selectedColor
+        }
+
+        // Color selection
+        if (!color) {
+          const colorOptions = [
+            ...DEFAULT_COLORS.map((c) => ({
+              name: `${c.name} (${c.value})`,
+              value: c.value,
+            })),
+            { name: "Custom color", value: "custom" },
+          ]
+
+          const selectedColor = await Select.prompt({
+            message: "Color:",
+            options: colorOptions,
+            default: DEFAULT_COLORS[6].value, // Indigo
+          })
+
+          if (selectedColor === "custom") {
+            color = await Input.prompt({
+              message: "Enter hex color (e.g., #FF5733):",
+              validate: (value) => {
+                if (!/^#[0-9A-Fa-f]{6}$/.test(value)) {
+                  return "Please enter a valid hex color (e.g., #FF5733)"
+                }
+                return true
+              },
+            })
+          } else {
+            color = selectedColor
+          }
+        }
+
+        // Description (optional)
+        if (!description) {
+          description = await Input.prompt({
+            message: "Description (optional):",
+          })
+          if (!description) description = undefined
+        }
+
+        // Team selection (optional)
+        if (teamKey === undefined) {
+          const allTeams = await getAllTeams()
+          const teamOptions = [
+            { name: "Workspace (shared by all teams)", value: "__workspace__" },
+            ...allTeams.map((t) => ({
+              name: `${t.name} (${t.key})`,
+              value: t.key,
+            })),
+          ]
+
+          // Try to get default team from config
+          const defaultTeam = getTeamKey()
+          const defaultIndex = defaultTeam
+            ? teamOptions.findIndex((t) => t.value === defaultTeam)
+            : 0
+
+          const selectedTeam = await Select.prompt({
+            message: "Team:",
+            options: teamOptions,
+            default: defaultIndex >= 0
+              ? teamOptions[defaultIndex].value
+              : "__workspace__",
+          })
+
+          teamKey = selectedTeam === "__workspace__" ? undefined : selectedTeam
         }
       }
 
-      // Description (optional)
-      if (!description) {
-        description = await Input.prompt({
-          message: "Description (optional):",
+      // Validate required fields
+      if (!name) {
+        throw new ValidationError("Label name is required", {
+          suggestion: "Use --name or -n flag to specify a label name.",
         })
-        if (!description) description = undefined
       }
 
-      // Team selection (optional)
-      if (teamKey === undefined) {
-        const allTeams = await getAllTeams()
-        const teamOptions = [
-          { name: "Workspace (shared by all teams)", value: "__workspace__" },
-          ...allTeams.map((t) => ({
-            name: `${t.name} (${t.key})`,
-            value: t.key,
-          })),
-        ]
-
-        // Try to get default team from config
-        const defaultTeam = getTeamKey()
-        const defaultIndex = defaultTeam
-          ? teamOptions.findIndex((t) => t.value === defaultTeam)
-          : 0
-
-        const selectedTeam = await Select.prompt({
-          message: "Team:",
-          options: teamOptions,
-          default: defaultIndex >= 0
-            ? teamOptions[defaultIndex].value
-            : "__workspace__",
-        })
-
-        teamKey = selectedTeam === "__workspace__" ? undefined : selectedTeam
+      // Validate color format if provided
+      if (color && !/^#[0-9A-Fa-f]{6}$/.test(color)) {
+        throw new ValidationError(
+          "Color must be a valid hex code (e.g., #EB5757)",
+        )
       }
-    }
 
-    // Validate required fields
-    if (!name) {
-      console.error("Label name is required. Use --name or -n flag.")
-      Deno.exit(1)
-    }
-
-    // Validate color format if provided
-    if (color && !/^#[0-9A-Fa-f]{6}$/.test(color)) {
-      console.error("Color must be a valid hex code (e.g., #EB5757)")
-      Deno.exit(1)
-    }
-
-    // Default color if not provided
-    if (!color) {
-      color = DEFAULT_COLORS[6].value // Indigo
-    }
-
-    // Build input
-    let teamId: string | undefined
-    if (teamKey) {
-      teamId = await getTeamIdByKey(teamKey.toUpperCase())
-      if (!teamId) {
-        console.error(`Team not found: ${teamKey}`)
-        Deno.exit(1)
+      // Default color if not provided
+      if (!color) {
+        color = DEFAULT_COLORS[6].value // Indigo
       }
-    }
 
-    const input = {
-      name,
-      color,
-      ...(description && { description }),
-      ...(teamId && { teamId }),
-    }
+      // Build input
+      let teamId: string | undefined
+      if (teamKey) {
+        teamId = await getTeamIdByKey(teamKey.toUpperCase())
+        if (!teamId) {
+          throw new NotFoundError("Team", teamKey)
+        }
+      }
 
-    const { Spinner } = await import("@std/cli/unstable-spinner")
-    const showSpinner = shouldShowSpinner()
-    const spinner = showSpinner ? new Spinner() : null
-    spinner?.start()
+      const input = {
+        name,
+        color,
+        ...(description && { description }),
+        ...(teamId && { teamId }),
+      }
 
-    try {
-      const result = await client.request(CreateIssueLabel, { input })
+      const { Spinner } = await import("@std/cli/unstable-spinner")
+      const showSpinner = shouldShowSpinner()
+      const spinner = showSpinner ? new Spinner() : null
+      spinner?.start()
 
-      if (!result.issueLabelCreate.success) {
+      try {
+        const result = await client.request(CreateIssueLabel, { input })
+
+        if (!result.issueLabelCreate.success) {
+          spinner?.stop()
+          throw new CliError("Failed to create label")
+        }
+
+        const label = result.issueLabelCreate.issueLabel
         spinner?.stop()
-        console.error("Failed to create label")
-        Deno.exit(1)
-      }
 
-      const label = result.issueLabelCreate.issueLabel
-      spinner?.stop()
-
-      console.log(`✓ Created label: ${label.name}`)
-      console.log(`  Color: ${label.color}`)
-      if (label.description) {
-        console.log(`  Description: ${label.description}`)
+        console.log(`✓ Created label: ${label.name}`)
+        console.log(`  Color: ${label.color}`)
+        if (label.description) {
+          console.log(`  Description: ${label.description}`)
+        }
+        console.log(
+          `  Scope: ${
+            label.team?.name
+              ? `${label.team.name} (${label.team.key})`
+              : "Workspace"
+          }`,
+        )
+      } catch (error) {
+        spinner?.stop()
+        throw error
       }
-      console.log(
-        `  Scope: ${
-          label.team?.name
-            ? `${label.team.name} (${label.team.key})`
-            : "Workspace"
-        }`,
-      )
     } catch (error) {
-      spinner?.stop()
-      console.error("Failed to create label:", error)
-      Deno.exit(1)
+      handleError(error, "Failed to create label")
     }
   })

--- a/src/commands/label/label-list.ts
+++ b/src/commands/label/label-list.ts
@@ -6,6 +6,7 @@ import { getGraphQLClient } from "../../utils/graphql.ts"
 import { padDisplay } from "../../utils/display.ts"
 import { getTeamKey } from "../../utils/linear.ts"
 import { shouldShowSpinner } from "../../utils/hyperlink.ts"
+import { handleError } from "../../utils/errors.ts"
 
 const GetIssueLabels = gql(`
   query GetIssueLabels($filter: IssueLabelFilter, $first: Int, $after: String) {
@@ -193,7 +194,6 @@ export const listCommand = new Command()
       console.log(`\n${sortedLabels.length} labels found.`)
     } catch (error) {
       spinner?.stop()
-      console.error("Failed to fetch labels:", error)
-      Deno.exit(1)
+      handleError(error, "Failed to fetch labels")
     }
   })

--- a/src/commands/milestone/milestone-create.ts
+++ b/src/commands/milestone/milestone-create.ts
@@ -3,6 +3,7 @@ import { gql } from "../../__codegen__/gql.ts"
 import { getGraphQLClient } from "../../utils/graphql.ts"
 import { resolveProjectId } from "../../utils/linear.ts"
 import { shouldShowSpinner } from "../../utils/hyperlink.ts"
+import { CliError, handleError } from "../../utils/errors.ts"
 
 const CreateProjectMilestone = gql(`
   mutation CreateProjectMilestone($input: ProjectMilestoneCreateInput!) {
@@ -61,13 +62,11 @@ export const createCommand = new Command()
             console.log(`  Project: ${milestone.project.name}`)
           }
         } else {
-          console.error("✗ Failed to create milestone")
-          Deno.exit(1)
+          throw new CliError("Failed to create milestone")
         }
       } catch (error) {
         spinner?.stop()
-        console.error("Failed to create milestone:", error)
-        Deno.exit(1)
+        handleError(error, "Failed to create milestone")
       }
     },
   )

--- a/src/commands/milestone/milestone-list.ts
+++ b/src/commands/milestone/milestone-list.ts
@@ -5,6 +5,7 @@ import { getGraphQLClient } from "../../utils/graphql.ts"
 import { padDisplay } from "../../utils/display.ts"
 import { resolveProjectId } from "../../utils/linear.ts"
 import { shouldShowSpinner } from "../../utils/hyperlink.ts"
+import { handleError } from "../../utils/errors.ts"
 
 const GetProjectMilestones = gql(`
   query GetProjectMilestones($projectId: String!) {
@@ -129,7 +130,6 @@ export const listCommand = new Command()
       }
     } catch (error) {
       spinner?.stop()
-      console.error("Failed to fetch milestones:", error)
-      Deno.exit(1)
+      handleError(error, "Failed to fetch milestones")
     }
   })

--- a/src/commands/milestone/milestone-view.ts
+++ b/src/commands/milestone/milestone-view.ts
@@ -4,6 +4,7 @@ import { gql } from "../../__codegen__/gql.ts"
 import { getGraphQLClient } from "../../utils/graphql.ts"
 import { formatRelativeTime } from "../../utils/display.ts"
 import { shouldShowSpinner } from "../../utils/hyperlink.ts"
+import { handleError, NotFoundError } from "../../utils/errors.ts"
 
 const GetMilestoneDetails = gql(`
   query GetMilestoneDetails($id: String!) {
@@ -56,8 +57,7 @@ export const viewCommand = new Command()
 
       const milestone = result.projectMilestone
       if (!milestone) {
-        console.error(`Milestone with ID "${milestoneId}" not found.`)
-        Deno.exit(1)
+        throw new NotFoundError("Milestone", milestoneId)
       }
 
       // Build the display
@@ -156,7 +156,6 @@ export const viewCommand = new Command()
       }
     } catch (error) {
       spinner?.stop()
-      console.error("Failed to fetch milestone details:", error)
-      Deno.exit(1)
+      handleError(error, "Failed to fetch milestone details")
     }
   })

--- a/src/commands/project/project-list.ts
+++ b/src/commands/project/project-list.ts
@@ -11,6 +11,7 @@ import { getTimeAgo, padDisplay } from "../../utils/display.ts"
 import { getTeamKey } from "../../utils/linear.ts"
 import { getOption } from "../../config.ts"
 import { shouldShowSpinner } from "../../utils/hyperlink.ts"
+import { handleError, ValidationError } from "../../utils/errors.ts"
 
 const GetProjects = gql(`
   query GetProjects($filter: ProjectFilter, $first: Int, $after: String) {
@@ -102,8 +103,9 @@ export const listCommand = new Command()
     try {
       // Validate conflicting flags
       if (team && allTeams) {
-        console.error("Cannot use both --team and --all-teams flags")
-        Deno.exit(1)
+        throw new ValidationError(
+          "Cannot use both --team and --all-teams flags",
+        )
       }
 
       // Determine team to filter by
@@ -332,7 +334,6 @@ export const listCommand = new Command()
       }
     } catch (error) {
       spinner?.stop()
-      console.error("Failed to fetch projects:", error)
-      Deno.exit(1)
+      handleError(error, "Failed to fetch projects")
     }
   })

--- a/src/commands/project/project-view.ts
+++ b/src/commands/project/project-view.ts
@@ -5,6 +5,7 @@ import { getGraphQLClient } from "../../utils/graphql.ts"
 import { formatRelativeTime } from "../../utils/display.ts"
 import { openProjectPage } from "../../utils/actions.ts"
 import { shouldShowSpinner } from "../../utils/hyperlink.ts"
+import { handleError, NotFoundError } from "../../utils/errors.ts"
 
 const GetProjectDetails = gql(`
   query GetProjectDetails($id: String!) {
@@ -97,8 +98,7 @@ export const viewCommand = new Command()
 
       const project = result.project
       if (!project) {
-        console.error(`Project with ID "${projectId}" not found.`)
-        Deno.exit(1)
+        throw new NotFoundError("Project", projectId)
       }
 
       // Build the display
@@ -249,7 +249,6 @@ export const viewCommand = new Command()
       }
     } catch (error) {
       spinner?.stop()
-      console.error("Failed to fetch project details:", error)
-      Deno.exit(1)
+      handleError(error, "Failed to fetch project details")
     }
   })

--- a/src/commands/team/team-autolinks.ts
+++ b/src/commands/team/team-autolinks.ts
@@ -1,6 +1,7 @@
 import { Command } from "@cliffy/command"
 import { getTeamKey } from "../../utils/linear.ts"
 import { getOption } from "../../config.ts"
+import { CliError, handleError, ValidationError } from "../../utils/errors.ts"
 
 export const autolinksCommand = new Command()
   .name("autolinks")
@@ -8,37 +9,41 @@ export const autolinksCommand = new Command()
     "Configure GitHub repository autolinks for Linear issues with this team prefix",
   )
   .action(async () => {
-    const teamId = getTeamKey()
-    if (!teamId) {
-      console.error("Could not determine team id from directory name.")
-      Deno.exit(1)
-    }
+    try {
+      const teamId = getTeamKey()
+      if (!teamId) {
+        throw new ValidationError(
+          "Could not determine team id from directory name",
+          { suggestion: "Run `linear configure` to set a team." },
+        )
+      }
 
-    const workspace = getOption("workspace")
-    if (!workspace) {
-      console.error(
-        "workspace is not set via command line, configuration file, or environment.",
-      )
-      Deno.exit(1)
-    }
+      const workspace = getOption("workspace")
+      if (!workspace) {
+        throw new ValidationError(
+          "workspace is not set via command line, configuration file, or environment",
+        )
+      }
 
-    const process = new Deno.Command("gh", {
-      args: [
-        "api",
-        "repos/{owner}/{repo}/autolinks",
-        "-f",
-        `key_prefix=${teamId}-`,
-        "-f",
-        `url_template=https://linear.app/${workspace}/issue/${teamId}-<num>`,
-      ],
-      stdin: "inherit",
-      stdout: "inherit",
-      stderr: "inherit",
-    })
+      const process = new Deno.Command("gh", {
+        args: [
+          "api",
+          "repos/{owner}/{repo}/autolinks",
+          "-f",
+          `key_prefix=${teamId}-`,
+          "-f",
+          `url_template=https://linear.app/${workspace}/issue/${teamId}-<num>`,
+        ],
+        stdin: "inherit",
+        stdout: "inherit",
+        stderr: "inherit",
+      })
 
-    const status = await process.spawn().status
-    if (!status.success) {
-      console.error("Failed to configure autolinks")
-      Deno.exit(1)
+      const status = await process.spawn().status
+      if (!status.success) {
+        throw new CliError("Failed to configure autolinks")
+      }
+    } catch (error) {
+      handleError(error, "Failed to configure autolinks")
     }
   })

--- a/src/commands/team/team-id.ts
+++ b/src/commands/team/team-id.ts
@@ -1,17 +1,22 @@
 import { Command } from "@cliffy/command"
 import { getTeamKey } from "../../utils/linear.ts"
+import { handleError, ValidationError } from "../../utils/errors.ts"
 
 export const idCommand = new Command()
   .name("id")
   .description("Print the configured team id")
   .action(() => {
-    const teamId = getTeamKey()
-    if (teamId) {
-      console.log(teamId)
-    } else {
-      console.error(
-        "No team id configured. Run `linear configure` to set a team.",
-      )
-      Deno.exit(1)
+    try {
+      const teamId = getTeamKey()
+      if (teamId) {
+        console.log(teamId)
+      } else {
+        throw new ValidationError(
+          "No team id configured",
+          { suggestion: "Run `linear configure` to set a team." },
+        )
+      }
+    } catch (error) {
+      handleError(error, "Failed to get team id")
     }
   })

--- a/src/commands/team/team-members.ts
+++ b/src/commands/team/team-members.ts
@@ -1,5 +1,6 @@
 import { Command } from "@cliffy/command"
 import { getTeamKey, getTeamMembers } from "../../utils/linear.ts"
+import { handleError, ValidationError } from "../../utils/errors.ts"
 
 export const membersCommand = new Command()
   .name("members")
@@ -7,15 +8,15 @@ export const membersCommand = new Command()
   .arguments("[teamKey:string]")
   .option("-a, --all", "Include inactive members")
   .action(async (options, teamKey?: string) => {
-    const resolvedTeamKey = teamKey || getTeamKey()
-    if (!resolvedTeamKey) {
-      console.error(
-        "Could not determine team key from directory name. Please specify a team key.",
-      )
-      Deno.exit(1)
-    }
-
     try {
+      const resolvedTeamKey = teamKey || getTeamKey()
+      if (!resolvedTeamKey) {
+        throw new ValidationError(
+          "Could not determine team key from directory name",
+          { suggestion: "Please specify a team key as an argument." },
+        )
+      }
+
       const members = await getTeamMembers(resolvedTeamKey)
 
       if (members.length === 0) {
@@ -70,10 +71,6 @@ export const membersCommand = new Command()
         console.log("")
       }
     } catch (error) {
-      console.error(
-        "Failed to fetch team members:",
-        error instanceof Error ? error.message : String(error),
-      )
-      Deno.exit(1)
+      handleError(error, "Failed to fetch team members")
     }
   })

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,12 @@ import "./credentials.ts"
 await new Command()
   .name("linear")
   .version(denoConfig.version)
-  .description("Handy linear commands from the command line")
+  .description(
+    `Handy linear commands from the command line.
+
+Environment Variables:
+  LINEAR_DEBUG=1    Show full error details including stack traces`,
+  )
   .globalOption(
     "-w, --workspace <slug:string>",
     "Target workspace (uses credentials)",

--- a/src/utils/bulk.ts
+++ b/src/utils/bulk.ts
@@ -6,6 +6,7 @@
  */
 
 import { shouldShowSpinner } from "./hyperlink.ts"
+import { NotFoundError } from "./errors.ts"
 
 /**
  * Result of a single bulk operation
@@ -76,7 +77,7 @@ export async function readIdsFromFile(filePath: string): Promise<string[]> {
     return parseIds(content)
   } catch (error) {
     if (error instanceof Deno.errors.NotFound) {
-      throw new Error(`File not found: ${filePath}`)
+      throw new NotFoundError("File", filePath)
     }
     throw error
   }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,267 @@
+/**
+ * User-friendly error handling for the Linear CLI.
+ *
+ * Design philosophy (inspired by Rust's error handling ecosystem):
+ * - User-facing messages should be clean and actionable
+ * - Stack traces only shown when LINEAR_DEBUG=1
+ * - Errors should explain what went wrong and suggest how to fix it
+ * - GraphQL errors should be parsed and presented nicely
+ */
+
+import { ClientError } from "graphql-request"
+import { gray, red, setColorEnabled } from "@std/fmt/colors"
+
+/**
+ * Check if debug mode is enabled via LINEAR_DEBUG environment variable.
+ */
+export function isDebugMode(): boolean {
+  const debug = Deno.env.get("LINEAR_DEBUG")
+  return debug === "1" || debug === "true"
+}
+
+/**
+ * Base class for CLI errors with user-friendly messages.
+ */
+export class CliError extends Error {
+  /** The clean, user-facing message */
+  readonly userMessage: string
+  /** Suggestion for how to fix the issue (optional) */
+  readonly suggestion?: string
+
+  constructor(
+    userMessage: string,
+    options?: { suggestion?: string; cause?: unknown },
+  ) {
+    super(userMessage)
+    this.name = "CliError"
+    this.userMessage = userMessage
+    this.suggestion = options?.suggestion
+    if (options?.cause) {
+      this.cause = options.cause
+    }
+  }
+}
+
+/**
+ * Error for when an entity (issue, project, team, etc.) is not found.
+ */
+export class NotFoundError extends CliError {
+  readonly entityType: string
+  readonly identifier: string
+
+  constructor(
+    entityType: string,
+    identifier: string,
+    options?: { suggestion?: string },
+  ) {
+    const message = `${entityType} not found: ${identifier}`
+    super(message, options)
+    this.name = "NotFoundError"
+    this.entityType = entityType
+    this.identifier = identifier
+  }
+}
+
+/**
+ * Error for invalid user input (arguments, flags, etc.).
+ */
+export class ValidationError extends CliError {
+  constructor(message: string, options?: { suggestion?: string }) {
+    super(message, options)
+    this.name = "ValidationError"
+  }
+}
+
+/**
+ * Error for authentication/authorization issues.
+ */
+export class AuthError extends CliError {
+  constructor(message: string, options?: { suggestion?: string }) {
+    super(message, {
+      suggestion: options?.suggestion ??
+        "Run `linear auth login` to authenticate.",
+      ...options,
+    })
+    this.name = "AuthError"
+  }
+}
+
+/**
+ * Extract a user-friendly message from a GraphQL ClientError.
+ *
+ * Tries to find:
+ * 1. userPresentableMessage from Linear's API
+ * 2. First error message from the response
+ * 3. Falls back to the error message
+ */
+export function extractGraphQLMessage(error: ClientError): string {
+  const extensions = error.response?.errors?.[0]?.extensions
+  const userMessage = extensions?.userPresentableMessage as string | undefined
+
+  if (userMessage) {
+    return userMessage
+  }
+
+  const firstError = error.response?.errors?.[0]
+  if (firstError?.message) {
+    return firstError.message
+  }
+
+  return error.message
+}
+
+/**
+ * Check if a GraphQL error indicates an entity was not found.
+ */
+export function isNotFoundError(error: ClientError): boolean {
+  const message = extractGraphQLMessage(error).toLowerCase()
+  return message.includes("not found") || message.includes("entity not found")
+}
+
+/**
+ * Check if an error is a GraphQL ClientError.
+ */
+export function isClientError(error: unknown): error is ClientError {
+  return error instanceof ClientError
+}
+
+/**
+ * Format and display an error to the user.
+ *
+ * In normal mode: Shows a clean, user-friendly message
+ * In debug mode (LINEAR_DEBUG=1): Also shows the full error details
+ */
+export function handleError(error: unknown, context?: string): never {
+  setColorEnabled(Deno.stderr.isTerminal())
+
+  if (error instanceof CliError) {
+    printCliError(error, context)
+  } else if (isClientError(error)) {
+    printGraphQLError(error, context)
+  } else if (error instanceof Error) {
+    printGenericError(error, context)
+  } else {
+    printUnknownError(error, context)
+  }
+
+  Deno.exit(1)
+}
+
+function printCliError(error: CliError, context?: string): void {
+  const prefix = context ? `${context}: ` : ""
+  console.error(red(`✗ ${prefix}${error.userMessage}`))
+
+  if (error.suggestion) {
+    console.error(gray(`  ${error.suggestion}`))
+  }
+
+  if (isDebugMode() && error.cause) {
+    printDebugInfo(error.cause)
+  }
+}
+
+function printGraphQLError(error: ClientError, context?: string): void {
+  const message = extractGraphQLMessage(error)
+  const prefix = context ? `${context}: ` : ""
+
+  // Check for common error patterns and provide helpful messages
+  if (isNotFoundError(error)) {
+    console.error(red(`✗ ${prefix}${message}`))
+  } else {
+    console.error(red(`✗ ${prefix}${message}`))
+  }
+
+  if (isDebugMode()) {
+    printDebugInfo(error)
+    const query = error.request?.query
+    const vars = error.request?.variables
+    if (query) {
+      console.error(gray("\nQuery:"))
+      console.error(gray(String(query).trim()))
+    }
+    if (vars) {
+      console.error(gray("\nVariables:"))
+      console.error(gray(JSON.stringify(vars, null, 2)))
+    }
+  }
+}
+
+function printGenericError(error: Error, context?: string): void {
+  const prefix = context ? `${context}: ` : ""
+  console.error(red(`✗ ${prefix}${error.message}`))
+
+  if (isDebugMode()) {
+    printDebugInfo(error)
+  }
+}
+
+function printUnknownError(error: unknown, context?: string): void {
+  const prefix = context ? `${context}: ` : ""
+  console.error(red(`✗ ${prefix}${String(error)}`))
+
+  if (isDebugMode()) {
+    console.error(gray("\nDebug info:"))
+    console.error(gray(JSON.stringify(error, null, 2)))
+  }
+}
+
+function printDebugInfo(error: unknown): void {
+  console.error(gray("\nStack trace (LINEAR_DEBUG=1):"))
+  if (error instanceof Error && error.stack) {
+    console.error(gray(error.stack))
+  }
+}
+
+/**
+ * Wrap an async operation with error handling.
+ * Similar to Rust's .context() for adding context to errors.
+ *
+ * @example
+ * const issue = await withContext(
+ *   () => getIssue(id),
+ *   "Failed to fetch issue"
+ * );
+ */
+export async function withContext<T>(
+  fn: () => Promise<T>,
+  context: string,
+): Promise<T> {
+  try {
+    return await fn()
+  } catch (error) {
+    if (error instanceof CliError) {
+      // Re-throw with context added
+      throw new CliError(`${context}: ${error.userMessage}`, {
+        suggestion: error.suggestion,
+        cause: error.cause ?? error,
+      })
+    }
+    if (isClientError(error)) {
+      const message = extractGraphQLMessage(error)
+      throw new CliError(`${context}: ${message}`, { cause: error })
+    }
+    if (error instanceof Error) {
+      throw new CliError(`${context}: ${error.message}`, { cause: error })
+    }
+    throw new CliError(`${context}: ${String(error)}`, { cause: error })
+  }
+}
+
+/**
+ * Create a standardized "not found" error handler for GraphQL queries.
+ *
+ * @example
+ * const issue = await client.request(query, { id })
+ *   .catch(handleNotFound("Issue", issueIdentifier));
+ */
+export function handleNotFound(
+  entityType: string,
+  identifier: string,
+): (error: unknown) => never {
+  return (error: unknown) => {
+    if (isClientError(error) && isNotFoundError(error)) {
+      throw new NotFoundError(entityType, identifier)
+    }
+    throw error
+  }
+}

--- a/test/commands/document/__snapshots__/document-create.test.ts.snap
+++ b/test/commands/document/__snapshots__/document-create.test.ts.snap
@@ -65,6 +65,7 @@ snapshot[`Document Create Command - Missing Title Error 1`] = `
 stdout:
 ""
 stderr:
-"Title is required. Use --title or run with -i for interactive mode.
+"✗ Failed to create document: Title is required
+  Use --title or run with -i for interactive mode.
 "
 `;

--- a/test/commands/document/__snapshots__/document-delete.test.ts.snap
+++ b/test/commands/document/__snapshots__/document-delete.test.ts.snap
@@ -34,7 +34,7 @@ snapshot[`Document Delete Command - Document Not Found 1`] = `
 stdout:
 ""
 stderr:
-"Document not found: nonexistent123
+"✗ Failed to delete document: Document not found: nonexistent123
 "
 `;
 
@@ -52,6 +52,7 @@ snapshot[`Document Delete Command - Missing ID 1`] = `
 stdout:
 ""
 stderr:
-"Document ID required. Use --bulk for multiple documents.
+"✗ Failed to delete document: Document ID required
+  Use --bulk for multiple documents.
 "
 `;

--- a/test/commands/document/__snapshots__/document-update.test.ts.snap
+++ b/test/commands/document/__snapshots__/document-update.test.ts.snap
@@ -54,6 +54,7 @@ snapshot[`Document Update Command - No Fields Provided 1`] = `
 stdout:
 ""
 stderr:
-"No update fields provided. Use --title, --content, --content-file, --icon, or --edit.
+"✗ Failed to update document: No update fields provided
+  Use --title, --content, --content-file, --icon, or --edit.
 "
 `;

--- a/test/commands/issue/__snapshots__/issue-describe.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-describe.test.ts.snap
@@ -43,9 +43,8 @@ stderr:
 
 snapshot[`Issue Describe Command - Issue Not Found 1`] = `
 stdout:
-'Error: Issue not found: TEST-999: {"response":{"errors":[{"message":"Issue not found: TEST-999","extensions":{"code":"NOT_FOUND"}}],"status":200,"headers":{}},"request":{"query":"query GetIssueDetails(\$id: String!) {\\\\n  issue(id: \$id) {\\\\n    identifier\\\\n    title\\\\n    description\\\\n    url\\\\n    branchName\\\\n    state {\\\\n      name\\\\n      color\\\\n    }\\\\n    parent {\\\\n      identifier\\\\n      title\\\\n      state {\\\\n        name\\\\n        color\\\\n      }\\\\n    }\\\\n    children {\\\\n      nodes {\\\\n        identifier\\\\n        title\\\\n        state {\\\\n          name\\\\n          color\\\\n        }\\\\n      }\\\\n    }\\\\n    attachments(first: 50) {\\\\n      nodes {\\\\n        id\\\\n        title\\\\n        url\\\\n        subtitle\\\\n        sourceType\\\\n        metadata\\\\n        createdAt\\\\n      }\\\\n    }\\\\n  }\\\\n}","variables":{"id":"TEST-999"}}}
-'
+""
 stderr:
-"✗ Failed to fetch issue details
+"✗ Failed to get issue description: Issue not found: TEST-999
 "
 `;

--- a/test/commands/issue/__snapshots__/issue-view.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-view.test.ts.snap
@@ -24,15 +24,6 @@ stderr:
 ""
 `;
 
-snapshot[`Issue View Command - With Issue ID 1`] = `
-stdout:
-"Error: error sending request for url (http://127.0.0.1:PORT/graphql): client error (Connect): tcp connect error: Connection refused
-"
-stderr:
-"✗ Failed to fetch issue details
-"
-`;
-
 snapshot[`Issue View Command - With Mock Server Terminal No Comments 1`] = `
 stdout:
 "# TEST-123: Fix authentication bug in login flow
@@ -93,15 +84,6 @@ Users are experiencing issues logging in when their session expires.
 "
 stderr:
 ""
-`;
-
-snapshot[`Issue View Command - Issue Not Found 1`] = `
-stdout:
-'Error: Issue not found: TEST-999: {"response":{"errors":[{"message":"Issue not found: TEST-999","extensions":{"code":"NOT_FOUND"}}],"status":200,"headers":{}},"request":{"query":"query GetIssueDetailsWithComments(\$id: String!) {\\\\n  issue(id: \$id) {\\\\n    identifier\\\\n    title\\\\n    description\\\\n    url\\\\n    branchName\\\\n    state {\\\\n      name\\\\n      color\\\\n    }\\\\n    parent {\\\\n      identifier\\\\n      title\\\\n      state {\\\\n        name\\\\n        color\\\\n      }\\\\n    }\\\\n    children {\\\\n      nodes {\\\\n        identifier\\\\n        title\\\\n        state {\\\\n          name\\\\n          color\\\\n        }\\\\n      }\\\\n    }\\\\n    comments(first: 50, orderBy: createdAt) {\\\\n      nodes {\\\\n        id\\\\n        body\\\\n        createdAt\\\\n        user {\\\\n          name\\\\n          displayName\\\\n        }\\\\n        externalUser {\\\\n          name\\\\n          displayName\\\\n        }\\\\n        parent {\\\\n          id\\\\n        }\\\\n      }\\\\n    }\\\\n    attachments(first: 50) {\\\\n      nodes {\\\\n        id\\\\n        title\\\\n        url\\\\n        subtitle\\\\n        sourceType\\\\n        metadata\\\\n        createdAt\\\\n      }\\\\n    }\\\\n  }\\\\n}","variables":{"id":"TEST-999"}}}
-'
-stderr:
-"✗ Failed to fetch issue details
-"
 `;
 
 snapshot[`Issue View Command - JSON Output No Comments 1`] = `
@@ -170,6 +152,14 @@ stdout:
 \`
 stderr:
 ""
+`;
+
+snapshot[`Issue View Command - Issue Not Found 1`] = `
+stdout:
+""
+stderr:
+"✗ Failed to view issue: Issue not found: TEST-999
+"
 `;
 
 snapshot[`Issue View Command - With Parent And Sub-issues 1`] = `

--- a/test/commands/issue/issue-describe.test.ts
+++ b/test/commands/issue/issue-describe.test.ts
@@ -103,6 +103,7 @@ await snapshotTest({
   name: "Issue Describe Command - Issue Not Found",
   meta: import.meta,
   colors: false,
+  canFail: true,
   args: ["TEST-999"],
   denoArgs,
   async fn() {
@@ -124,11 +125,7 @@ await snapshotTest({
       Deno.env.set("LINEAR_GRAPHQL_ENDPOINT", server.getEndpoint())
       Deno.env.set("LINEAR_API_KEY", "Bearer test-token")
 
-      try {
-        await describeCommand.parse()
-      } catch (error) {
-        console.log(`Error: ${(error as Error).message}`)
-      }
+      await describeCommand.parse()
     } finally {
       await server.stop()
       Deno.env.delete("LINEAR_GRAPHQL_ENDPOINT")

--- a/test/utils/errors.test.ts
+++ b/test/utils/errors.test.ts
@@ -1,0 +1,111 @@
+import { assertEquals } from "@std/assert"
+import {
+  CliError,
+  extractGraphQLMessage,
+  isClientError,
+  isDebugMode,
+  isNotFoundError,
+  NotFoundError,
+  ValidationError,
+} from "../../src/utils/errors.ts"
+import { ClientError, type GraphQLResponse } from "graphql-request"
+
+Deno.test("isDebugMode - returns false when LINEAR_DEBUG is not set", () => {
+  Deno.env.delete("LINEAR_DEBUG")
+  assertEquals(isDebugMode(), false)
+})
+
+Deno.test("isDebugMode - returns true when LINEAR_DEBUG is '1'", () => {
+  Deno.env.set("LINEAR_DEBUG", "1")
+  try {
+    assertEquals(isDebugMode(), true)
+  } finally {
+    Deno.env.delete("LINEAR_DEBUG")
+  }
+})
+
+Deno.test("isDebugMode - returns true when LINEAR_DEBUG is 'true'", () => {
+  Deno.env.set("LINEAR_DEBUG", "true")
+  try {
+    assertEquals(isDebugMode(), true)
+  } finally {
+    Deno.env.delete("LINEAR_DEBUG")
+  }
+})
+
+Deno.test("CliError - stores user message", () => {
+  const error = new CliError("Something went wrong")
+  assertEquals(error.userMessage, "Something went wrong")
+  assertEquals(error.message, "Something went wrong")
+})
+
+Deno.test("CliError - stores suggestion", () => {
+  const error = new CliError("Something went wrong", {
+    suggestion: "Try running with --force",
+  })
+  assertEquals(error.suggestion, "Try running with --force")
+})
+
+Deno.test("NotFoundError - formats message correctly", () => {
+  const error = new NotFoundError("Issue", "ENG-123")
+  assertEquals(error.userMessage, "Issue not found: ENG-123")
+  assertEquals(error.entityType, "Issue")
+  assertEquals(error.identifier, "ENG-123")
+})
+
+Deno.test("ValidationError - stores message and suggestion", () => {
+  const error = new ValidationError("Invalid relation type: foo", {
+    suggestion: "Must be one of: blocks, related",
+  })
+  assertEquals(error.userMessage, "Invalid relation type: foo")
+  assertEquals(error.suggestion, "Must be one of: blocks, related")
+})
+
+// Helper to create test ClientError instances
+function createClientError(
+  message: string,
+  userPresentableMessage?: string,
+): ClientError {
+  const response = {
+    status: 200,
+    errors: [
+      {
+        message,
+        extensions: userPresentableMessage
+          ? { userPresentableMessage }
+          : undefined,
+      },
+    ],
+  } as unknown as GraphQLResponse<unknown>
+  return new ClientError(response, { query: "query {}" })
+}
+
+Deno.test("extractGraphQLMessage - extracts userPresentableMessage", () => {
+  const error = createClientError("Internal error", "Issue not found")
+  assertEquals(extractGraphQLMessage(error), "Issue not found")
+})
+
+Deno.test("extractGraphQLMessage - falls back to error message", () => {
+  const error = createClientError("Entity not found: Issue")
+  assertEquals(extractGraphQLMessage(error), "Entity not found: Issue")
+})
+
+Deno.test("isNotFoundError - returns true for 'not found' messages", () => {
+  const error = createClientError("Entity not found: Issue")
+  assertEquals(isNotFoundError(error), true)
+})
+
+Deno.test("isNotFoundError - returns false for other errors", () => {
+  const error = createClientError("Authentication required")
+  assertEquals(isNotFoundError(error), false)
+})
+
+Deno.test("isClientError - returns true for ClientError", () => {
+  const error = createClientError("Some error")
+  assertEquals(isClientError(error), true)
+})
+
+Deno.test("isClientError - returns false for other errors", () => {
+  const error = new Error("Some error")
+  assertEquals(isClientError(error), false)
+})


### PR DESCRIPTION
feat: user-friendly error messages with debug mode support

Add a centralized error handling module inspired by Rust's error handling
patterns (anyhow, thiserror) that provides:

- Clean, user-friendly error messages by default
- Stack traces only shown when LINEAR_DEBUG=1 (similar to RUST_BACKTRACE=1)
- Specialized error types: CliError, NotFoundError, ValidationError, AuthError
- GraphQL error message extraction from Linear API responses
- handleError() function for consistent error display across commands

Update issue-relation command to use the new error handling:
- Use ValidationError for invalid input
- Use NotFoundError for missing issues/relations
- All errors now show clean messages without stack traces by default

Fixes #116