### PR TITLE
feat: add --sort-order to milestone update

### DIFF
--- a/src/commands/milestone/milestone-update.ts
+++ b/src/commands/milestone/milestone-update.ts
@@ -13,6 +13,7 @@ const UpdateProjectMilestone = gql(`
         id
         name
         targetDate
+        sortOrder
         project {
           id
           name
@@ -29,16 +30,25 @@ export const updateCommand = new Command()
   .option("--name <name:string>", "Milestone name")
   .option("--description <description:string>", "Milestone description")
   .option("--target-date <date:string>", "Target date (YYYY-MM-DD)")
+  .option(
+    "--sort-order <value:number>",
+    "Sort order relative to other milestones",
+  )
   .option("--project <projectId:string>", "Move to a different project")
   .action(
-    async ({ name, description, targetDate, project: projectIdOrSlug }, id) => {
-      // Check if at least one update option is provided
-      if (!name && !description && !targetDate && !projectIdOrSlug) {
+    async (
+      { name, description, targetDate, sortOrder, project: projectIdOrSlug },
+      id,
+    ) => {
+      if (
+        !name && !description && !targetDate && sortOrder == null &&
+        !projectIdOrSlug
+      ) {
         throw new ValidationError(
           "At least one update option must be provided",
           {
             suggestion:
-              "Use --name, --description, --target-date, or --project",
+              "Use --name, --description, --target-date, --sort-order, or --project",
           },
         )
       }
@@ -55,6 +65,7 @@ export const updateCommand = new Command()
         if (name) input.name = name
         if (description) input.description = description
         if (targetDate) input.targetDate = targetDate
+        if (sortOrder != null) input.sortOrder = sortOrder
         if (projectIdOrSlug) {
           // Resolve project slug to full UUID
           input.projectId = await resolveProjectId(projectIdOrSlug)
@@ -74,6 +85,7 @@ export const updateCommand = new Command()
             if (milestone.targetDate) {
               console.log(`  Target Date: ${milestone.targetDate}`)
             }
+            console.log(`  Sort Order: ${milestone.sortOrder}`)
             console.log(`  Project: ${milestone.project.name}`)
           }
         } else {

--- a/test/commands/issue/__snapshots__/issue-view.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-view.test.ts.snap
@@ -86,6 +86,14 @@ stderr:
 ""
 `;
 
+snapshot[`Issue View Command - Issue Not Found 1`] = `
+stdout:
+""
+stderr:
+"✗ Failed to view issue: Issue not found: TEST-999
+"
+`;
+
 snapshot[`Issue View Command - JSON Output No Comments 1`] = `
 stdout:
 '{
@@ -152,14 +160,6 @@ stdout:
 \`
 stderr:
 ""
-`;
-
-snapshot[`Issue View Command - Issue Not Found 1`] = `
-stdout:
-""
-stderr:
-"✗ Failed to view issue: Issue not found: TEST-999
-"
 `;
 
 snapshot[`Issue View Command - With Parent And Sub-issues 1`] = `

--- a/test/commands/milestone/__snapshots__/milestone-update.test.ts.snap
+++ b/test/commands/milestone/__snapshots__/milestone-update.test.ts.snap
@@ -11,11 +11,12 @@ Description:
 
 Options:
 
-  -h, --help                    - Show this help.              
-  --name         <name>         - Milestone name               
-  --description  <description>  - Milestone description        
-  --target-date  <date>         - Target date (YYYY-MM-DD)     
-  --project      <projectId>    - Move to a different project  
+  -h, --help                    - Show this help.                          
+  --name         <name>         - Milestone name                           
+  --description  <description>  - Milestone description                    
+  --target-date  <date>         - Target date (YYYY-MM-DD)                 
+  --sort-order   <value>        - Sort order relative to other milestones  
+  --project      <projectId>    - Move to a different project              
 
 "
 stderr:
@@ -27,6 +28,7 @@ stdout:
 "✓ Updated milestone: Updated Milestone Name
   ID: milestone-123
   Target Date: 2026-03-31
+  Sort Order: 0
   Project: Test Project
 "
 stderr:
@@ -38,7 +40,32 @@ stdout:
 "✓ Updated milestone: Q2 Goals
   ID: milestone-456
   Target Date: 2026-06-30
+  Sort Order: 1
   Project: Another Project
+"
+stderr:
+""
+`;
+
+snapshot[`Milestone Update Command - Update Sort Order 1`] = `
+stdout:
+"✓ Updated milestone: Sorted Milestone
+  ID: milestone-sort
+  Target Date: 2026-06-15
+  Sort Order: 5
+  Project: Test Project
+"
+stderr:
+""
+`;
+
+snapshot[`Milestone Update Command - Update Sort Order Zero 1`] = `
+stdout:
+"✓ Updated milestone: First Milestone
+  ID: milestone-zero
+  Target Date: 2026-01-15
+  Sort Order: 0
+  Project: Test Project
 "
 stderr:
 ""
@@ -49,6 +76,7 @@ stdout:
 "✓ Updated milestone: Existing Milestone
   ID: milestone-789
   Target Date: 2026-12-31
+  Sort Order: 2
   Project: Final Project
 "
 stderr:

--- a/test/commands/milestone/milestone-update.test.ts
+++ b/test/commands/milestone/milestone-update.test.ts
@@ -38,6 +38,7 @@ await cliffySnapshotTest({
                 id: "milestone-123",
                 name: "Updated Milestone Name",
                 targetDate: "2026-03-31",
+                sortOrder: 0,
                 project: {
                   id: "project-123",
                   name: "Test Project",
@@ -90,9 +91,108 @@ await cliffySnapshotTest({
                 id: "milestone-456",
                 name: "Q2 Goals",
                 targetDate: "2026-06-30",
+                sortOrder: 1,
                 project: {
                   id: "project-789",
                   name: "Another Project",
+                },
+              },
+            },
+          },
+        },
+      },
+    ])
+
+    try {
+      await server.start()
+      Deno.env.set("LINEAR_GRAPHQL_ENDPOINT", server.getEndpoint())
+      Deno.env.set("LINEAR_API_KEY", "Bearer test-token")
+
+      await updateCommand.parse()
+    } finally {
+      await server.stop()
+      Deno.env.delete("LINEAR_GRAPHQL_ENDPOINT")
+      Deno.env.delete("LINEAR_API_KEY")
+    }
+  },
+})
+
+// Test milestone update - sort order only
+await cliffySnapshotTest({
+  name: "Milestone Update Command - Update Sort Order",
+  meta: import.meta,
+  colors: false,
+  args: [
+    "milestone-sort",
+    "--sort-order",
+    "5",
+  ],
+  denoArgs: commonDenoArgs,
+  async fn() {
+    const server = new MockLinearServer([
+      {
+        queryName: "UpdateProjectMilestone",
+        response: {
+          data: {
+            projectMilestoneUpdate: {
+              success: true,
+              projectMilestone: {
+                id: "milestone-sort",
+                name: "Sorted Milestone",
+                targetDate: "2026-06-15",
+                sortOrder: 5,
+                project: {
+                  id: "project-123",
+                  name: "Test Project",
+                },
+              },
+            },
+          },
+        },
+      },
+    ])
+
+    try {
+      await server.start()
+      Deno.env.set("LINEAR_GRAPHQL_ENDPOINT", server.getEndpoint())
+      Deno.env.set("LINEAR_API_KEY", "Bearer test-token")
+
+      await updateCommand.parse()
+    } finally {
+      await server.stop()
+      Deno.env.delete("LINEAR_GRAPHQL_ENDPOINT")
+      Deno.env.delete("LINEAR_API_KEY")
+    }
+  },
+})
+
+// Test milestone update - sort order zero (guards against truthiness-check regression)
+await cliffySnapshotTest({
+  name: "Milestone Update Command - Update Sort Order Zero",
+  meta: import.meta,
+  colors: false,
+  args: [
+    "milestone-zero",
+    "--sort-order",
+    "0",
+  ],
+  denoArgs: commonDenoArgs,
+  async fn() {
+    const server = new MockLinearServer([
+      {
+        queryName: "UpdateProjectMilestone",
+        response: {
+          data: {
+            projectMilestoneUpdate: {
+              success: true,
+              projectMilestone: {
+                id: "milestone-zero",
+                name: "First Milestone",
+                targetDate: "2026-01-15",
+                sortOrder: 0,
+                project: {
+                  id: "project-123",
+                  name: "Test Project",
                 },
               },
             },
@@ -138,6 +238,7 @@ await cliffySnapshotTest({
                 id: "milestone-789",
                 name: "Existing Milestone",
                 targetDate: "2026-12-31",
+                sortOrder: 2,
                 project: {
                   id: "project-999",
                   name: "Final Project",


### PR DESCRIPTION
Add `--sort-order <value>` flag to `linear milestone update`, exposing the `sortOrder` field that was already available in the GraphQL schema's `ProjectMilestoneUpdateInput` but not as a CLI option.

## Changes

- Add `--sort-order <value:number>` option to the update command
- Include `sortOrder` in the mutation response and display it in output
- Use `== null` / `!= null` checks (not truthiness) so `--sort-order 0` works correctly
- Update validation error message to list the new flag

## Testing

- Snapshot test for `--sort-order 5`
- Dedicated edge case test for `--sort-order 0` to guard against truthiness-check regressions
- Updated existing mock responses to include `sortOrder` field
