### PR TITLE
feat: increase sub-issues limit from 50 to 250

### DIFF
--- a/src/utils/linear.ts
+++ b/src/utils/linear.ts
@@ -220,7 +220,7 @@ export async function fetchIssueDetails(
               color
             }
           }
-          children {
+          children(first: 250) {
             nodes {
               identifier
               title
@@ -283,7 +283,7 @@ export async function fetchIssueDetails(
               color
             }
           }
-          children {
+          children(first: 250) {
             nodes {
               identifier
               title


### PR DESCRIPTION
## Summary

- The `children` GraphQL query defaults to 50 items, which truncates issues with many sub-issues
- Bumps the limit to 250 (verified the API supports this)

## Test plan

- [x] Verified `first: 250` works via direct API call
- [x] All tests pass
- [x] `deno check` and `deno lint` pass

🤖 Generated with [Claude Code](https://claude.ai/code)