### PR TITLE
fix: don't create new commit after describing in issue start

### DIFF
--- a/src/utils/vcs.ts
+++ b/src/utils/vcs.ts
@@ -1,7 +1,6 @@
 import { getOption } from "../config.ts"
 import { fetchIssueDetails } from "./linear.ts"
 import {
-  createJjNewChange,
   formatIssueDescription,
   getJjLinearIssue,
   prepareJjWorkingState,
@@ -132,9 +131,6 @@ export async function startVcsWork(
       const { title, url } = await fetchIssueDetails(issueId, false)
       const description = formatIssueDescription(issueId, title, url)
       await setJjDescription(description)
-
-      // Create a new empty change to work on
-      await createJjNewChange()
 
       console.log(`✓ Prepared jj change for issue ${issueId}`)
       break


### PR DESCRIPTION
fix: don't create new commit after describing in issue start

Previously,  with jj would:
1. Prepare working state (create empty commit if needed)
2. Describe the commit with issue details
3. Create a new empty commit to work on

This left the user on an empty commit with the described commit as parent.

Now it stops after step 2, leaving the user on the described commit itself.
This matches the expected behavior where you work directly on the commit
associated with the issue.