### PR TITLE
feat: add --description-file flag and warn on literal \n sequences

### DIFF
--- a/skills/linear-cli/references/issue.md
+++ b/skills/linear-cli/references/issue.md
@@ -274,6 +274,7 @@ Options:
   --priority                 <priority>     - Priority of the issue (1-4, descending priority)             
   --estimate                 <estimate>     - Points estimate of the issue                                 
   -d, --description          <description>  - Description of the issue                                     
+  --description-file         <path>         - Read description from file                                   
   -l, --label                <label>        - Issue label associated with the issue. May be repeated.      
   --team                     <team>         - Team associated with the issue (if not your default team)    
   --project                  <project>      - Name of the project with the issue                           
@@ -297,19 +298,20 @@ Description:
 
 Options:
 
-  -h, --help                        - Show this help.                                              
-  -w, --workspace    <slug>         - Target workspace (uses credentials)                          
-  -a, --assignee     <assignee>     - Assign the issue to 'self' or someone (by username or name)  
-  --due-date         <dueDate>      - Due date of the issue                                        
-  -p, --parent       <parent>       - Parent issue (if any) as a team_number code                  
-  --priority         <priority>     - Priority of the issue (1-4, descending priority)             
-  --estimate         <estimate>     - Points estimate of the issue                                 
-  -d, --description  <description>  - Description of the issue                                     
-  -l, --label        <label>        - Issue label associated with the issue. May be repeated.      
-  --team             <team>         - Team associated with the issue (if not your default team)    
-  --project          <project>      - Name of the project with the issue                           
-  -s, --state        <state>        - Workflow state for the issue (by name or type)               
-  -t, --title        <title>        - Title of the issue
+  -h, --help                         - Show this help.
+  -w, --workspace     <slug>         - Target workspace (uses credentials)
+  -a, --assignee      <assignee>     - Assign the issue to 'self' or someone (by username or name)
+  --due-date          <dueDate>      - Due date of the issue
+  -p, --parent        <parent>       - Parent issue (if any) as a team_number code
+  --priority          <priority>     - Priority of the issue (1-4, descending priority)
+  --estimate          <estimate>     - Points estimate of the issue
+  -d, --description   <description>  - Description of the issue
+  --description-file  <path>         - Read description from file
+  -l, --label         <label>        - Issue label associated with the issue. May be repeated.
+  --team              <team>         - Team associated with the issue (if not your default team)
+  --project           <project>      - Name of the project with the issue
+  -s, --state         <state>        - Workflow state for the issue (by name or type)
+  -t, --title         <title>        - Title of the issue
 ```
 
 ### comment
@@ -353,6 +355,7 @@ Options:
   -h, --help                   - Show this help.                                            
   -w, --workspace  <slug>      - Target workspace (uses credentials)                        
   -b, --body       <text>      - Comment body text                                          
+  --body-file      <path>      - Read comment body from file                                
   -p, --parent     <id>        - Parent comment ID for replies                              
   -a, --attach     <filepath>  - Attach a file to the comment (can be used multiple times)
 ```
@@ -371,7 +374,8 @@ Options:
 
   -h, --help               - Show this help.                      
   -w, --workspace  <slug>  - Target workspace (uses credentials)  
-  -b, --body       <text>  - New comment body text
+  -b, --body       <text>  - New comment body text                
+  --body-file      <path>  - Read comment body from file
 ```
 
 ##### list

--- a/src/commands/issue/issue-comment-update.ts
+++ b/src/commands/issue/issue-comment-update.ts
@@ -2,19 +2,90 @@ import { Command } from "@cliffy/command"
 import { Input } from "@cliffy/prompt"
 import { gql } from "../../__codegen__/gql.ts"
 import { getGraphQLClient } from "../../utils/graphql.ts"
-import { CliError, handleError, ValidationError } from "../../utils/errors.ts"
+import {
+  CliError,
+  handleError,
+  NotFoundError,
+  ValidationError,
+} from "../../utils/errors.ts"
+
+/**
+ * Helper function to read body from file
+ */
+async function readBodyFromFile(filePath: string): Promise<string> {
+  try {
+    return await Deno.readTextFile(filePath)
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      throw new NotFoundError("File", filePath)
+    }
+    throw new CliError(
+      `Failed to read body file: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { cause: error },
+    )
+  }
+}
+
+/**
+ * Warn if the body contains literal escaped newlines (\n as two characters)
+ * without actual line breaks, which can indicate improper shell escaping
+ */
+function warnIfLiteralEscapedNewlines(body: string): void {
+  // Check for literal backslash-n sequences that don't represent actual newlines
+  // This pattern matches \n that aren't preceded by another backslash
+  const hasLiteralBackslashN = /(?<!\\)\\n/.test(body)
+
+  // Also check if the body has very few actual newlines relative to the \n occurrences
+  const backslashNCount = (body.match(/\\n/g) || []).length
+  const actualNewlineCount = (body.match(/\n/g) || []).length
+
+  if (hasLiteralBackslashN && backslashNCount > actualNewlineCount) {
+    console.warn(
+      "⚠️  Warning: Your comment contains literal '\\n' sequences that may not render as line breaks.",
+    )
+    console.warn(
+      "   For multiline comments, consider using --body-file or shell-specific syntax:",
+    )
+    console.warn("   • Bash: --body $'line 1\\nline 2'")
+    console.warn("   • Or save to a file: --body-file comment.md")
+    console.warn()
+  }
+}
 
 export const commentUpdateCommand = new Command()
   .name("update")
   .description("Update an existing comment")
   .arguments("<commentId:string>")
   .option("-b, --body <text:string>", "New comment body text")
+  .option("--body-file <path:string>", "Read comment body from file")
   .action(async (options, commentId) => {
-    const { body } = options
+    const { body, bodyFile } = options
 
     try {
+      // Validate that both --body and --body-file are not used together
+      if (body && bodyFile) {
+        throw new ValidationError(
+          "Cannot use both --body and --body-file",
+          {
+            suggestion: "Choose one method to provide the comment body.",
+          },
+        )
+      }
+
       let newBody = body
       let existingBody = ""
+
+      // Read body from file if --body-file is provided
+      if (bodyFile) {
+        newBody = await readBodyFromFile(bodyFile)
+      }
+
+      // Warn if body contains literal \n sequences
+      if (newBody) {
+        warnIfLiteralEscapedNewlines(newBody)
+      }
 
       // If no body provided, fetch existing comment to show as default
       if (!newBody) {

--- a/test/commands/issue/__snapshots__/issue-create.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-create.test.ts.snap
@@ -19,6 +19,7 @@ Options:
   --priority                 <priority>     - Priority of the issue (1-4, descending priority)             
   --estimate                 <estimate>     - Points estimate of the issue                                 
   -d, --description          <description>  - Description of the issue                                     
+  --description-file         <path>         - Read description from file                                   
   -l, --label                <label>        - Issue label associated with the issue. May be repeated.      
   --team                     <team>         - Team associated with the issue (if not your default team)    
   --project                  <project>      - Name of the project with the issue                           

--- a/test/commands/issue/__snapshots__/issue-update.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-update.test.ts.snap
@@ -11,18 +11,19 @@ Description:
 
 Options:
 
-  -h, --help                        - Show this help.                                              
-  -a, --assignee     <assignee>     - Assign the issue to 'self' or someone (by username or name)  
-  --due-date         <dueDate>      - Due date of the issue                                        
-  -p, --parent       <parent>       - Parent issue (if any) as a team_number code                  
-  --priority         <priority>     - Priority of the issue (1-4, descending priority)             
-  --estimate         <estimate>     - Points estimate of the issue                                 
-  -d, --description  <description>  - Description of the issue                                     
-  -l, --label        <label>        - Issue label associated with the issue. May be repeated.      
-  --team             <team>         - Team associated with the issue (if not your default team)    
-  --project          <project>      - Name of the project with the issue                           
-  -s, --state        <state>        - Workflow state for the issue (by name or type)               
-  -t, --title        <title>        - Title of the issue                                           
+  -h, --help                         - Show this help.                                              
+  -a, --assignee      <assignee>     - Assign the issue to 'self' or someone (by username or name)  
+  --due-date          <dueDate>      - Due date of the issue                                        
+  -p, --parent        <parent>       - Parent issue (if any) as a team_number code                  
+  --priority          <priority>     - Priority of the issue (1-4, descending priority)             
+  --estimate          <estimate>     - Points estimate of the issue                                 
+  -d, --description   <description>  - Description of the issue                                     
+  --description-file  <path>         - Read description from file                                   
+  -l, --label         <label>        - Issue label associated with the issue. May be repeated.      
+  --team              <team>         - Team associated with the issue (if not your default team)    
+  --project           <project>      - Name of the project with the issue                           
+  -s, --state         <state>        - Workflow state for the issue (by name or type)               
+  -t, --title         <title>        - Title of the issue                                           
 
 "
 stderr:


### PR DESCRIPTION
feat: add --description-file flag and warn on literal \n sequences

Fixes #133

Adds support for reading issue descriptions from files via
--description-file flag in both issue create and issue update commands.

Also adds detection and warning when descriptions contain literal
escaped newlines (\n as two characters) that won't render as line
breaks, providing guidance on proper multiline syntax.

Changes:
- Add --description-file flag to issue create/update commands
- Add validation to prevent using both --description and --description-file
- Add warnIfLiteralEscapedNewlines() to detect improper shell escaping
- Update skill documentation via generate-docs script
- Update test snapshots for new help output