### PR TITLE
Add CI check for skill docs and update documentation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,3 +28,18 @@ jobs:
 
       - name: Run tests
         run: deno task test
+
+      - name: Install linear-cli for skill generation
+        run: deno task install
+
+      - name: Check skill docs are up-to-date
+        run: |
+          deno task generate-skill-docs
+          if ! git diff --exit-code skills/; then
+            echo "Error: Generated skill documentation is out of date"
+            echo "Please run: deno task generate-skill-docs"
+            echo ""
+            echo "Changes needed:"
+            git diff skills/
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -251,6 +251,34 @@ npx skills add schpet/linear-cli
 
 view the skill at [skills.sh/schpet/linear-cli/linear-cli](https://skills.sh/schpet/linear-cli/linear-cli)
 
+## development
+
+### updating skill documentation
+
+the skill documentation in `skills/linear-cli/` is automatically generated from the CLI help text. after making changes to commands or help text, regenerate the docs:
+
+```bash
+deno task generate-skill-docs
+```
+
+this will:
+
+- discover all commands and subcommands from `linear --help`
+- generate reference documentation for each command
+- update the `SKILL.md` file from `SKILL.template.md`
+
+**important:** the CI checks will fail if the generated docs are out of date, so make sure to run this before committing changes that affect command structure or help text.
+
+### code formatting
+
+ensure code is formatted consistently:
+
+```bash
+deno fmt
+```
+
+the project uses deno's built-in formatter with configuration in `deno.json`. formatting is checked in CI.
+
 ## why
 
 linear's UI is incredibly good but it slows me down. i find the following pretty grating to experience frequently:

--- a/skills/linear-cli/references/api.md
+++ b/skills/linear-cli/references/api.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear api [query]
-Version: 1.9.1
+Version: 1.9.1             
 
 Description:
 
@@ -14,10 +14,11 @@ Description:
 
 Options:
 
-  -h, --help                        - Show this help.
-  -w, --workspace         <slug>    - Target workspace (uses credentials)
-  --variable              <variable> - Variable in key=value format (coerces booleans, numbers, null; @file reads from path)
-  --variables-json        <json>    - JSON object of variables (merged with --variable, which takes precedence)
-  --paginate                        - Automatically fetch all pages using cursor pagination
-  --silent                          - Suppress response output (exit code still reflects errors)
+  -h, --help                    - Show this help.                                                                  
+  -w, --workspace   <slug>      - Target workspace (uses credentials)                                              
+  --variable        <variable>  - Variable in key=value format (coerces booleans, numbers, null; @file reads from  
+                                  path)                                                                            
+  --variables-json  <json>      - JSON object of variables (merged with --variable, which takes precedence)        
+  --paginate                    - Auto-paginate a single connection field using cursor pagination                  
+  --silent                      - Suppress response output (exit code still reflects errors)
 ```

--- a/skills/linear-cli/references/auth.md
+++ b/skills/linear-cli/references/auth.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear auth
-Version: 1.8.1      
+Version: 1.9.1      
 
 Description:
 
@@ -35,7 +35,7 @@ Commands:
 
 ```
 Usage:   linear auth login
-Version: 1.8.1            
+Version: 1.9.1            
 
 Description:
 
@@ -54,7 +54,7 @@ Options:
 
 ```
 Usage:   linear auth logout [workspace]
-Version: 1.8.1                         
+Version: 1.9.1                         
 
 Description:
 
@@ -73,7 +73,7 @@ Options:
 
 ```
 Usage:   linear auth list
-Version: 1.8.1           
+Version: 1.9.1           
 
 Description:
 
@@ -91,7 +91,7 @@ Options:
 
 ```
 Usage:   linear auth default [workspace]
-Version: 1.8.1                          
+Version: 1.9.1                          
 
 Description:
 
@@ -109,7 +109,7 @@ Options:
 
 ```
 Usage:   linear auth token
-Version: 1.8.1            
+Version: 1.9.1            
 
 Description:
 
@@ -127,7 +127,7 @@ Options:
 
 ```
 Usage:   linear auth whoami
-Version: 1.8.1             
+Version: 1.9.1             
 
 Description:
 

--- a/skills/linear-cli/references/config.md
+++ b/skills/linear-cli/references/config.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear config
-Version: 1.8.1        
+Version: 1.9.1        
 
 Description:
 

--- a/skills/linear-cli/references/document.md
+++ b/skills/linear-cli/references/document.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear document
-Version: 1.8.1          
+Version: 1.9.1          
 
 Description:
 
@@ -34,7 +34,7 @@ Commands:
 
 ```
 Usage:   linear document list
-Version: 1.8.1               
+Version: 1.9.1               
 
 Description:
 
@@ -56,7 +56,7 @@ Options:
 
 ```
 Usage:   linear document view <id>
-Version: 1.8.1                    
+Version: 1.9.1                    
 
 Description:
 
@@ -77,7 +77,7 @@ Options:
 
 ```
 Usage:   linear document create
-Version: 1.8.1                 
+Version: 1.9.1                 
 
 Description:
 
@@ -93,8 +93,7 @@ Options:
   --project           <project>  - Attach to project (slug or ID)            
   --issue             <issue>    - Attach to issue (identifier like TC-123)  
   --icon              <icon>     - Document icon (emoji)                     
-  -i, --interactive              - Interactive mode with prompts             
-  --no-color                     - Disable colored output
+  -i, --interactive              - Interactive mode with prompts
 ```
 
 ### update
@@ -103,7 +102,7 @@ Options:
 
 ```
 Usage:   linear document update <documentId>
-Version: 1.8.1                              
+Version: 1.9.1                              
 
 Description:
 
@@ -117,8 +116,7 @@ Options:
   -c, --content       <content>  - New markdown content (inline)                
   -f, --content-file  <path>     - Read new content from file                   
   --icon              <icon>     - New icon (emoji)                             
-  -e, --edit                     - Open current content in $EDITOR for editing  
-  --no-color                     - Disable colored output
+  -e, --edit                     - Open current content in $EDITOR for editing
 ```
 
 ### delete
@@ -127,7 +125,7 @@ Options:
 
 ```
 Usage:   linear document delete [documentId]
-Version: 1.8.1                              
+Version: 1.9.1                              
 
 Description:
 
@@ -138,7 +136,6 @@ Options:
   -h, --help                 - Show this help.                                     
   -w, --workspace  <slug>    - Target workspace (uses credentials)                 
   -y, --yes                  - Skip confirmation prompt                            
-  --no-color                 - Disable colored output                              
   --bulk           <ids...>  - Delete multiple documents by slug or ID             
   --bulk-file      <file>    - Read document slugs/IDs from a file (one per line)  
   --bulk-stdin               - Read document slugs/IDs from stdin

--- a/skills/linear-cli/references/initiative-update.md
+++ b/skills/linear-cli/references/initiative-update.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear initiative-update
-Version: 1.8.1                   
+Version: 1.9.1                   
 
 Description:
 
@@ -31,7 +31,7 @@ Commands:
 
 ```
 Usage:   linear initiative-update create <initiativeId>
-Version: 1.8.1                                         
+Version: 1.9.1                                         
 
 Description:
 
@@ -44,8 +44,7 @@ Options:
   --body             <body>    - Update content (markdown)                  
   --body-file        <path>    - Read content from file                     
   --health           <health>  - Health status (onTrack, atRisk, offTrack)  
-  -i, --interactive            - Interactive mode with prompts              
-  --no-color                   - Disable colored output
+  -i, --interactive            - Interactive mode with prompts
 ```
 
 ### list
@@ -54,7 +53,7 @@ Options:
 
 ```
 Usage:   linear initiative-update list <initiativeId>
-Version: 1.8.1                                       
+Version: 1.9.1                                       
 
 Description:
 

--- a/skills/linear-cli/references/initiative.md
+++ b/skills/linear-cli/references/initiative.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear initiative
-Version: 1.8.1            
+Version: 1.9.1            
 
 Description:
 
@@ -38,7 +38,7 @@ Commands:
 
 ```
 Usage:   linear initiative list
-Version: 1.8.1                 
+Version: 1.9.1                 
 
 Description:
 
@@ -63,7 +63,7 @@ Options:
 
 ```
 Usage:   linear initiative view <initiativeId>
-Version: 1.8.1                                
+Version: 1.9.1                                
 
 Description:
 
@@ -84,7 +84,7 @@ Options:
 
 ```
 Usage:   linear initiative create
-Version: 1.8.1                   
+Version: 1.9.1                   
 
 Description:
 
@@ -101,8 +101,7 @@ Options:
   --target-date      <targetDate>   - Target completion date (YYYY-MM-DD)                    
   -c, --color        <color>        - Color hex code (e.g., #5E6AD2)                         
   --icon             <icon>         - Icon name                                              
-  -i, --interactive                 - Interactive mode (default if no flags provided)        
-  --no-color                        - Disable colored output
+  -i, --interactive                 - Interactive mode (default if no flags provided)
 ```
 
 ### archive
@@ -111,7 +110,7 @@ Options:
 
 ```
 Usage:   linear initiative archive [initiativeId]
-Version: 1.8.1                                   
+Version: 1.9.1                                   
 
 Description:
 
@@ -122,7 +121,6 @@ Options:
   -h, --help                 - Show this help.                                    
   -w, --workspace  <slug>    - Target workspace (uses credentials)                
   -y, --force                - Skip confirmation prompt                           
-  --no-color                 - Disable colored output                             
   --bulk           <ids...>  - Archive multiple initiatives by ID, slug, or name  
   --bulk-file      <file>    - Read initiative IDs from a file (one per line)     
   --bulk-stdin               - Read initiative IDs from stdin
@@ -134,7 +132,7 @@ Options:
 
 ```
 Usage:   linear initiative update <initiativeId>
-Version: 1.8.1                                  
+Version: 1.9.1                                  
 
 Description:
 
@@ -151,8 +149,7 @@ Options:
   --target-date      <targetDate>   - Target completion date (YYYY-MM-DD)              
   --color            <color>        - Initiative color (hex, e.g., #5E6AD2)            
   --icon             <icon>         - Initiative icon name                             
-  -i, --interactive                 - Interactive mode for updates                     
-  --no-color                        - Disable colored output
+  -i, --interactive                 - Interactive mode for updates
 ```
 
 ### unarchive
@@ -161,7 +158,7 @@ Options:
 
 ```
 Usage:   linear initiative unarchive <initiativeId>
-Version: 1.8.1                                     
+Version: 1.9.1                                     
 
 Description:
 
@@ -171,8 +168,7 @@ Options:
 
   -h, --help               - Show this help.                      
   -w, --workspace  <slug>  - Target workspace (uses credentials)  
-  -y, --force              - Skip confirmation prompt             
-  --no-color               - Disable colored output
+  -y, --force              - Skip confirmation prompt
 ```
 
 ### delete
@@ -181,7 +177,7 @@ Options:
 
 ```
 Usage:   linear initiative delete [initiativeId]
-Version: 1.8.1                                  
+Version: 1.9.1                                  
 
 Description:
 
@@ -192,7 +188,6 @@ Options:
   -h, --help                 - Show this help.                                   
   -w, --workspace  <slug>    - Target workspace (uses credentials)               
   -y, --force                - Skip confirmation prompt                          
-  --no-color                 - Disable colored output                            
   --bulk           <ids...>  - Delete multiple initiatives by ID, slug, or name  
   --bulk-file      <file>    - Read initiative IDs from a file (one per line)    
   --bulk-stdin               - Read initiative IDs from stdin
@@ -204,7 +199,7 @@ Options:
 
 ```
 Usage:   linear initiative add-project <initiative> <project>
-Version: 1.8.1                                               
+Version: 1.9.1                                               
 
 Description:
 
@@ -214,8 +209,7 @@ Options:
 
   -h, --help                    - Show this help.                      
   -w, --workspace  <slug>       - Target workspace (uses credentials)  
-  --sort-order     <sortOrder>  - Sort order within initiative         
-  --no-color                    - Disable colored output
+  --sort-order     <sortOrder>  - Sort order within initiative
 ```
 
 ### remove-project
@@ -224,7 +218,7 @@ Options:
 
 ```
 Usage:   linear initiative remove-project <initiative> <project>
-Version: 1.8.1                                                  
+Version: 1.9.1                                                  
 
 Description:
 
@@ -234,6 +228,5 @@ Options:
 
   -h, --help               - Show this help.                      
   -w, --workspace  <slug>  - Target workspace (uses credentials)  
-  -y, --force              - Skip confirmation prompt             
-  --no-color               - Disable colored output
+  -y, --force              - Skip confirmation prompt
 ```

--- a/skills/linear-cli/references/issue.md
+++ b/skills/linear-cli/references/issue.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear issue
-Version: 1.8.1       
+Version: 1.9.1       
 
 Description:
 
@@ -32,7 +32,8 @@ Commands:
   create                                  - Create a linear issue                              
   update            [issueId]             - Update a linear issue                              
   comment                                 - Manage issue comments                              
-  attach            <issueId> <filepath>  - Attach a file to an issue
+  attach            <issueId> <filepath>  - Attach a file to an issue                          
+  relation                                - Manage issue relations (dependencies)
 ```
 
 ## Subcommands
@@ -43,7 +44,7 @@ Commands:
 
 ```
 Usage:   linear issue id
-Version: 1.8.1          
+Version: 1.9.1          
 
 Description:
 
@@ -61,7 +62,7 @@ Options:
 
 ```
 Usage:   linear issue list
-Version: 1.8.1            
+Version: 1.9.1            
 
 Description:
 
@@ -92,7 +93,7 @@ Options:
 
 ```
 Usage:   linear issue title [issueId]
-Version: 1.8.1                       
+Version: 1.9.1                       
 
 Description:
 
@@ -110,7 +111,7 @@ Options:
 
 ```
 Usage:   linear issue start [issueId]
-Version: 1.8.1                       
+Version: 1.9.1                       
 
 Description:
 
@@ -132,7 +133,7 @@ Options:
 
 ```
 Usage:   linear issue view [issueId]
-Version: 1.8.1                      
+Version: 1.9.1                      
 
 Description:
 
@@ -156,7 +157,7 @@ Options:
 
 ```
 Usage:   linear issue url [issueId]
-Version: 1.8.1                     
+Version: 1.9.1                     
 
 Description:
 
@@ -174,7 +175,7 @@ Options:
 
 ```
 Usage:   linear issue describe [issueId]
-Version: 1.8.1                          
+Version: 1.9.1                          
 
 Description:
 
@@ -193,7 +194,7 @@ Options:
 
 ```
 Usage:   linear issue commits [issueId]
-Version: 1.8.1                         
+Version: 1.9.1                         
 
 Description:
 
@@ -211,7 +212,7 @@ Options:
 
 ```
 Usage:   linear issue pull-request [issueId]
-Version: 1.8.1                              
+Version: 1.9.1                              
 
 Description:
 
@@ -234,7 +235,7 @@ Options:
 
 ```
 Usage:   linear issue delete [issueId]
-Version: 1.8.1                        
+Version: 1.9.1                        
 
 Description:
 
@@ -245,7 +246,6 @@ Options:
   -h, --help                 - Show this help.                                             
   -w, --workspace  <slug>    - Target workspace (uses credentials)                         
   -y, --confirm              - Skip confirmation prompt                                    
-  --no-color                 - Disable colored output                                      
   --bulk           <ids...>  - Delete multiple issues by identifier (e.g., TC-123 TC-124)  
   --bulk-file      <file>    - Read issue identifiers from a file (one per line)           
   --bulk-stdin               - Read issue identifiers from stdin
@@ -257,7 +257,7 @@ Options:
 
 ```
 Usage:   linear issue create
-Version: 1.8.1              
+Version: 1.9.1              
 
 Description:
 
@@ -279,7 +279,6 @@ Options:
   --project                  <project>      - Name of the project with the issue                           
   -s, --state                <state>        - Workflow state for the issue (by name or type)               
   --no-use-default-template                 - Do not use default template for the issue                    
-  --no-color                                - Disable colored output                                       
   --no-interactive                          - Disable interactive prompts                                  
   -t, --title                <title>        - Title of the issue
 ```
@@ -290,7 +289,7 @@ Options:
 
 ```
 Usage:   linear issue update [issueId]
-Version: 1.8.1                        
+Version: 1.9.1                        
 
 Description:
 
@@ -310,7 +309,6 @@ Options:
   --team             <team>         - Team associated with the issue (if not your default team)    
   --project          <project>      - Name of the project with the issue                           
   -s, --state        <state>        - Workflow state for the issue (by name or type)               
-  --no-color                        - Disable colored output                                       
   -t, --title        <title>        - Title of the issue
 ```
 
@@ -320,7 +318,7 @@ Options:
 
 ```
 Usage:   linear issue comment
-Version: 1.8.1               
+Version: 1.9.1               
 
 Description:
 
@@ -344,7 +342,7 @@ Commands:
 
 ```
 Usage:   linear issue comment add [issueId]
-Version: 1.8.1                             
+Version: 1.9.1                             
 
 Description:
 
@@ -363,7 +361,7 @@ Options:
 
 ```
 Usage:   linear issue comment update <commentId>
-Version: 1.8.1                                  
+Version: 1.9.1                                  
 
 Description:
 
@@ -380,7 +378,7 @@ Options:
 
 ```
 Usage:   linear issue comment list [issueId]
-Version: 1.8.1                              
+Version: 1.9.1                              
 
 Description:
 
@@ -399,7 +397,7 @@ Options:
 
 ```
 Usage:   linear issue attach <issueId> <filepath>
-Version: 1.8.1                                   
+Version: 1.9.1                                   
 
 Description:
 
@@ -411,4 +409,85 @@ Options:
   -w, --workspace  <slug>   - Target workspace (uses credentials)          
   -t, --title      <title>  - Custom title for the attachment              
   -c, --comment    <body>   - Add a comment body linked to the attachment
+```
+
+### relation
+
+> Manage issue relations (dependencies)
+
+```
+Usage:   linear issue relation
+Version: 1.9.1                
+
+Description:
+
+  Manage issue relations (dependencies)
+
+Options:
+
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
+
+Commands:
+
+  add     <issueId> <relationType> <relatedIssueId>  - Add a relation between two issues   
+  delete  <issueId> <relationType> <relatedIssueId>  - Delete a relation between two issues
+  list    [issueId]                                  - List relations for an issue
+```
+
+#### relation subcommands
+
+##### add
+
+```
+Usage:   linear issue relation add <issueId> <relationType> <relatedIssueId>
+Version: 1.9.1                                                              
+
+Description:
+
+  Add a relation between two issues
+
+Options:
+
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)  
+
+Examples:
+
+  Mark issue as blocked by another linear issue relation add ENG-123 blocked-by ENG-100
+  Mark issue as blocking another   linear issue relation add ENG-123 blocks ENG-456    
+  Mark issues as related           linear issue relation add ENG-123 related ENG-456   
+  Mark issue as duplicate          linear issue relation add ENG-123 duplicate ENG-100
+```
+
+##### delete
+
+```
+Usage:   linear issue relation delete <issueId> <relationType> <relatedIssueId>
+Version: 1.9.1                                                                 
+
+Description:
+
+  Delete a relation between two issues
+
+Options:
+
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)
+```
+
+##### list
+
+```
+Usage:   linear issue relation list [issueId]
+Version: 1.9.1                               
+
+Description:
+
+  List relations for an issue
+
+Options:
+
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)
 ```

--- a/skills/linear-cli/references/label.md
+++ b/skills/linear-cli/references/label.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear label
-Version: 1.8.1       
+Version: 1.9.1       
 
 Description:
 
@@ -32,7 +32,7 @@ Commands:
 
 ```
 Usage:   linear label list
-Version: 1.8.1            
+Version: 1.9.1            
 
 Description:
 
@@ -53,7 +53,7 @@ Options:
 
 ```
 Usage:   linear label create
-Version: 1.8.1              
+Version: 1.9.1              
 
 Description:
 
@@ -76,7 +76,7 @@ Options:
 
 ```
 Usage:   linear label delete <nameOrId>
-Version: 1.8.1                         
+Version: 1.9.1                         
 
 Description:
 

--- a/skills/linear-cli/references/milestone.md
+++ b/skills/linear-cli/references/milestone.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear milestone
-Version: 1.8.1           
+Version: 1.9.1           
 
 Description:
 
@@ -34,7 +34,7 @@ Commands:
 
 ```
 Usage:   linear milestone list --project <projectId>
-Version: 1.8.1                                      
+Version: 1.9.1                                      
 
 Description:
 
@@ -53,7 +53,7 @@ Options:
 
 ```
 Usage:   linear milestone view <milestoneId>
-Version: 1.8.1                              
+Version: 1.9.1                              
 
 Description:
 
@@ -71,7 +71,7 @@ Options:
 
 ```
 Usage:   linear milestone create --project <projectId> --name <name>
-Version: 1.8.1                                                      
+Version: 1.9.1                                                      
 
 Description:
 
@@ -93,7 +93,7 @@ Options:
 
 ```
 Usage:   linear milestone update <id>
-Version: 1.8.1                       
+Version: 1.9.1                       
 
 Description:
 
@@ -101,11 +101,12 @@ Description:
 
 Options:
 
-  -h, --help                      - Show this help.                      
-  -w, --workspace  <slug>         - Target workspace (uses credentials)  
-  --name           <name>         - Milestone name                       
-  --description    <description>  - Milestone description                
-  --target-date    <date>         - Target date (YYYY-MM-DD)             
+  -h, --help                      - Show this help.                          
+  -w, --workspace  <slug>         - Target workspace (uses credentials)      
+  --name           <name>         - Milestone name                           
+  --description    <description>  - Milestone description                    
+  --target-date    <date>         - Target date (YYYY-MM-DD)                 
+  --sort-order     <value>        - Sort order relative to other milestones  
   --project        <projectId>    - Move to a different project
 ```
 
@@ -115,7 +116,7 @@ Options:
 
 ```
 Usage:   linear milestone delete <id>
-Version: 1.8.1                       
+Version: 1.9.1                       
 
 Description:
 

--- a/skills/linear-cli/references/project-update.md
+++ b/skills/linear-cli/references/project-update.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear project-update
-Version: 1.8.1                
+Version: 1.9.1                
 
 Description:
 
@@ -31,7 +31,7 @@ Commands:
 
 ```
 Usage:   linear project-update create <projectId>
-Version: 1.8.1                                   
+Version: 1.9.1                                   
 
 Description:
 
@@ -44,8 +44,7 @@ Options:
   --body             <body>    - Update content (inline)                            
   --body-file        <path>    - Read content from file                             
   --health           <health>  - Project health status (onTrack, atRisk, offTrack)  
-  -i, --interactive            - Interactive mode with prompts                      
-  --no-color                   - Disable colored output
+  -i, --interactive            - Interactive mode with prompts
 ```
 
 ### list
@@ -54,7 +53,7 @@ Options:
 
 ```
 Usage:   linear project-update list <projectId>
-Version: 1.8.1                                 
+Version: 1.9.1                                 
 
 Description:
 

--- a/skills/linear-cli/references/project.md
+++ b/skills/linear-cli/references/project.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear project
-Version: 1.8.1         
+Version: 1.9.1         
 
 Description:
 
@@ -32,7 +32,7 @@ Commands:
 
 ```
 Usage:   linear project list
-Version: 1.8.1              
+Version: 1.9.1              
 
 Description:
 
@@ -55,7 +55,7 @@ Options:
 
 ```
 Usage:   linear project view <projectId>
-Version: 1.8.1                          
+Version: 1.9.1                          
 
 Description:
 
@@ -75,7 +75,7 @@ Options:
 
 ```
 Usage:   linear project create
-Version: 1.8.1                
+Version: 1.9.1                
 
 Description:
 
@@ -93,6 +93,5 @@ Options:
   --start-date       <startDate>    - Start date (YYYY-MM-DD)                                                  
   --target-date      <targetDate>   - Target completion date (YYYY-MM-DD)                                      
   --initiative       <initiative>   - Add to initiative immediately (ID, slug, or name)                        
-  -i, --interactive                 - Interactive mode (default if no flags provided)                          
-  --no-color                        - Disable colored output
+  -i, --interactive                 - Interactive mode (default if no flags provided)
 ```

--- a/skills/linear-cli/references/schema.md
+++ b/skills/linear-cli/references/schema.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear schema
-Version: 1.8.1        
+Version: 1.9.1        
 
 Description:
 

--- a/skills/linear-cli/references/team.md
+++ b/skills/linear-cli/references/team.md
@@ -6,7 +6,7 @@
 
 ```
 Usage:   linear team
-Version: 1.8.1      
+Version: 1.9.1      
 
 Description:
 
@@ -35,7 +35,7 @@ Commands:
 
 ```
 Usage:   linear team create
-Version: 1.8.1             
+Version: 1.9.1             
 
 Description:
 
@@ -49,7 +49,6 @@ Options:
   -d, --description  <description>  - Description of the team                                  
   -k, --key          <key>          - Team key (if not provided, will be generated from name)  
   --private                         - Make the team private                                    
-  --no-color                        - Disable colored output                                   
   --no-interactive                  - Disable interactive prompts
 ```
 
@@ -59,7 +58,7 @@ Options:
 
 ```
 Usage:   linear team delete <teamKey>
-Version: 1.8.1                       
+Version: 1.9.1                       
 
 Description:
 
@@ -79,7 +78,7 @@ Options:
 
 ```
 Usage:   linear team list
-Version: 1.8.1           
+Version: 1.9.1           
 
 Description:
 
@@ -99,7 +98,7 @@ Options:
 
 ```
 Usage:   linear team id
-Version: 1.8.1         
+Version: 1.9.1         
 
 Description:
 
@@ -117,7 +116,7 @@ Options:
 
 ```
 Usage:   linear team autolinks
-Version: 1.8.1                
+Version: 1.9.1                
 
 Description:
 
@@ -135,7 +134,7 @@ Options:
 
 ```
 Usage:   linear team members [teamKey]
-Version: 1.8.1                        
+Version: 1.9.1                        
 
 Description:
 

--- a/skills/linear-cli/scripts/generate-docs.ts
+++ b/skills/linear-cli/scripts/generate-docs.ts
@@ -256,6 +256,18 @@ async function main() {
   await Deno.writeTextFile(SKILL_MD, skillContent)
   console.log("  Generated: SKILL.md")
 
+  // Format all generated files
+  console.log("\nFormatting generated files...")
+  const fmtResult = await run([
+    "deno",
+    "fmt",
+    SKILL_DIR,
+  ])
+  if (!fmtResult.success) {
+    console.error("Warning: Failed to format generated files")
+    console.error(fmtResult.stderr)
+  }
+
   console.log(`\nDone! Generated ${commands.length + 2} files.`)
 }
 


### PR DESCRIPTION
Add CI check for skill docs and update documentation

- Add CI workflow step to verify generated skill docs are up-to-date
- Add development section to README with instructions for:
  - Updating skill documentation with deno task generate-skill-docs
  - Running code formatting with deno fmt
- Update generate-docs.ts to automatically format generated files
- Regenerate skill docs to ensure they match current CLI version

Fixes #135