### PR TITLE
Add file-based flags for markdown content in issue and comment commands

### DIFF
--- a/skills/linear-cli/SKILL.md
+++ b/skills/linear-cli/SKILL.md
@@ -21,6 +21,44 @@ linear --version
 If not installed, follow the instructions at:\
 https://github.com/schpet/linear-cli?tab=readme-ov-file#install
 
+## Best Practices for Markdown Content
+
+When working with issue descriptions or comment bodies that contain markdown, **always prefer using file-based flags** instead of passing content as command-line arguments:
+
+- Use `--description-file` for `issue create` and `issue update` commands
+- Use `--body-file` for `comment add` and `comment update` commands
+
+**Why use file-based flags:**
+
+- Ensures proper formatting in the Linear web UI
+- Avoids shell escaping issues with newlines and special characters
+- Prevents literal `\n` sequences from appearing in markdown
+- Makes it easier to work with multi-line content
+
+**Example workflow:**
+
+```bash
+# Write markdown to a temporary file
+cat > /tmp/description.md <<'EOF'
+## Summary
+
+- First item
+- Second item
+
+## Details
+
+This is a detailed description with proper formatting.
+EOF
+
+# Create issue using the file
+linear issue create --title "My Issue" --description-file /tmp/description.md
+
+# Or for comments
+linear issue comment add ENG-123 --body-file /tmp/comment.md
+```
+
+**Only use inline flags** (`--description`, `--body`) for simple, single-line content.
+
 ## Available Commands
 
 ```

--- a/skills/linear-cli/SKILL.template.md
+++ b/skills/linear-cli/SKILL.template.md
@@ -21,6 +21,44 @@ linear --version
 If not installed, follow the instructions at:\
 https://github.com/schpet/linear-cli?tab=readme-ov-file#install
 
+## Best Practices for Markdown Content
+
+When working with issue descriptions or comment bodies that contain markdown, **always prefer using file-based flags** instead of passing content as command-line arguments:
+
+- Use `--description-file` for `issue create` and `issue update` commands
+- Use `--body-file` for `comment add` and `comment update` commands
+
+**Why use file-based flags:**
+
+- Ensures proper formatting in the Linear web UI
+- Avoids shell escaping issues with newlines and special characters
+- Prevents literal `\n` sequences from appearing in markdown
+- Makes it easier to work with multi-line content
+
+**Example workflow:**
+
+```bash
+# Write markdown to a temporary file
+cat > /tmp/description.md <<'EOF'
+## Summary
+
+- First item
+- Second item
+
+## Details
+
+This is a detailed description with proper formatting.
+EOF
+
+# Create issue using the file
+linear issue create --title "My Issue" --description-file /tmp/description.md
+
+# Or for comments
+linear issue comment add ENG-123 --body-file /tmp/comment.md
+```
+
+**Only use inline flags** (`--description`, `--body`) for simple, single-line content.
+
 ## Available Commands
 
 {{COMMANDS}}

--- a/skills/linear-cli/references/issue.md
+++ b/skills/linear-cli/references/issue.md
@@ -265,21 +265,22 @@ Description:
 
 Options:
 
-  -h, --help                                - Show this help.                                              
-  -w, --workspace            <slug>         - Target workspace (uses credentials)                          
-  --start                                   - Start the issue after creation                               
-  -a, --assignee             <assignee>     - Assign the issue to 'self' or someone (by username or name)  
-  --due-date                 <dueDate>      - Due date of the issue                                        
-  -p, --parent               <parent>       - Parent issue (if any) as a team_number code                  
-  --priority                 <priority>     - Priority of the issue (1-4, descending priority)             
-  --estimate                 <estimate>     - Points estimate of the issue                                 
-  -d, --description          <description>  - Description of the issue                                     
-  -l, --label                <label>        - Issue label associated with the issue. May be repeated.      
-  --team                     <team>         - Team associated with the issue (if not your default team)    
-  --project                  <project>      - Name of the project with the issue                           
-  -s, --state                <state>        - Workflow state for the issue (by name or type)               
-  --no-use-default-template                 - Do not use default template for the issue                    
-  --no-interactive                          - Disable interactive prompts                                  
+  -h, --help                                - Show this help.                                                
+  -w, --workspace            <slug>         - Target workspace (uses credentials)                            
+  --start                                   - Start the issue after creation                                 
+  -a, --assignee             <assignee>     - Assign the issue to 'self' or someone (by username or name)    
+  --due-date                 <dueDate>      - Due date of the issue                                          
+  -p, --parent               <parent>       - Parent issue (if any) as a team_number code                    
+  --priority                 <priority>     - Priority of the issue (1-4, descending priority)               
+  --estimate                 <estimate>     - Points estimate of the issue                                   
+  -d, --description          <description>  - Description of the issue                                       
+  --description-file         <path>         - Read description from a file (preferred for markdown content)  
+  -l, --label                <label>        - Issue label associated with the issue. May be repeated.        
+  --team                     <team>         - Team associated with the issue (if not your default team)      
+  --project                  <project>      - Name of the project with the issue                             
+  -s, --state                <state>        - Workflow state for the issue (by name or type)                 
+  --no-use-default-template                 - Do not use default template for the issue                      
+  --no-interactive                          - Disable interactive prompts                                    
   -t, --title                <title>        - Title of the issue
 ```
 
@@ -297,19 +298,20 @@ Description:
 
 Options:
 
-  -h, --help                        - Show this help.                                              
-  -w, --workspace    <slug>         - Target workspace (uses credentials)                          
-  -a, --assignee     <assignee>     - Assign the issue to 'self' or someone (by username or name)  
-  --due-date         <dueDate>      - Due date of the issue                                        
-  -p, --parent       <parent>       - Parent issue (if any) as a team_number code                  
-  --priority         <priority>     - Priority of the issue (1-4, descending priority)             
-  --estimate         <estimate>     - Points estimate of the issue                                 
-  -d, --description  <description>  - Description of the issue                                     
-  -l, --label        <label>        - Issue label associated with the issue. May be repeated.      
-  --team             <team>         - Team associated with the issue (if not your default team)    
-  --project          <project>      - Name of the project with the issue                           
-  -s, --state        <state>        - Workflow state for the issue (by name or type)               
-  -t, --title        <title>        - Title of the issue
+  -h, --help                         - Show this help.                                                
+  -w, --workspace     <slug>         - Target workspace (uses credentials)                            
+  -a, --assignee      <assignee>     - Assign the issue to 'self' or someone (by username or name)    
+  --due-date          <dueDate>      - Due date of the issue                                          
+  -p, --parent        <parent>       - Parent issue (if any) as a team_number code                    
+  --priority          <priority>     - Priority of the issue (1-4, descending priority)               
+  --estimate          <estimate>     - Points estimate of the issue                                   
+  -d, --description   <description>  - Description of the issue                                       
+  --description-file  <path>         - Read description from a file (preferred for markdown content)  
+  -l, --label         <label>        - Issue label associated with the issue. May be repeated.        
+  --team              <team>         - Team associated with the issue (if not your default team)      
+  --project           <project>      - Name of the project with the issue                             
+  -s, --state         <state>        - Workflow state for the issue (by name or type)                 
+  -t, --title         <title>        - Title of the issue
 ```
 
 ### comment
@@ -350,10 +352,11 @@ Description:
 
 Options:
 
-  -h, --help                   - Show this help.                                            
-  -w, --workspace  <slug>      - Target workspace (uses credentials)                        
-  -b, --body       <text>      - Comment body text                                          
-  -p, --parent     <id>        - Parent comment ID for replies                              
+  -h, --help                   - Show this help.                                                 
+  -w, --workspace  <slug>      - Target workspace (uses credentials)                             
+  -b, --body       <text>      - Comment body text                                               
+  --body-file      <path>      - Read comment body from a file (preferred for markdown content)  
+  -p, --parent     <id>        - Parent comment ID for replies                                   
   -a, --attach     <filepath>  - Attach a file to the comment (can be used multiple times)
 ```
 
@@ -369,9 +372,10 @@ Description:
 
 Options:
 
-  -h, --help               - Show this help.                      
-  -w, --workspace  <slug>  - Target workspace (uses credentials)  
-  -b, --body       <text>  - New comment body text
+  -h, --help               - Show this help.                                                 
+  -w, --workspace  <slug>  - Target workspace (uses credentials)                             
+  -b, --body       <text>  - New comment body text                                           
+  --body-file      <path>  - Read comment body from a file (preferred for markdown content)
 ```
 
 ##### list

--- a/test/commands/issue/__snapshots__/issue-create.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-create.test.ts.snap
@@ -11,21 +11,22 @@ Description:
 
 Options:
 
-  -h, --help                                - Show this help.                                              
-  --start                                   - Start the issue after creation                               
-  -a, --assignee             <assignee>     - Assign the issue to 'self' or someone (by username or name)  
-  --due-date                 <dueDate>      - Due date of the issue                                        
-  -p, --parent               <parent>       - Parent issue (if any) as a team_number code                  
-  --priority                 <priority>     - Priority of the issue (1-4, descending priority)             
-  --estimate                 <estimate>     - Points estimate of the issue                                 
-  -d, --description          <description>  - Description of the issue                                     
-  -l, --label                <label>        - Issue label associated with the issue. May be repeated.      
-  --team                     <team>         - Team associated with the issue (if not your default team)    
-  --project                  <project>      - Name of the project with the issue                           
-  -s, --state                <state>        - Workflow state for the issue (by name or type)               
-  --no-use-default-template                 - Do not use default template for the issue                    
-  --no-interactive                          - Disable interactive prompts                                  
-  -t, --title                <title>        - Title of the issue                                           
+  -h, --help                                - Show this help.                                                
+  --start                                   - Start the issue after creation                                 
+  -a, --assignee             <assignee>     - Assign the issue to 'self' or someone (by username or name)    
+  --due-date                 <dueDate>      - Due date of the issue                                          
+  -p, --parent               <parent>       - Parent issue (if any) as a team_number code                    
+  --priority                 <priority>     - Priority of the issue (1-4, descending priority)               
+  --estimate                 <estimate>     - Points estimate of the issue                                   
+  -d, --description          <description>  - Description of the issue                                       
+  --description-file         <path>         - Read description from a file (preferred for markdown content)  
+  -l, --label                <label>        - Issue label associated with the issue. May be repeated.        
+  --team                     <team>         - Team associated with the issue (if not your default team)      
+  --project                  <project>      - Name of the project with the issue                             
+  -s, --state                <state>        - Workflow state for the issue (by name or type)                 
+  --no-use-default-template                 - Do not use default template for the issue                      
+  --no-interactive                          - Disable interactive prompts                                    
+  -t, --title                <title>        - Title of the issue                                             
 
 "
 stderr:

--- a/test/commands/issue/__snapshots__/issue-update.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-update.test.ts.snap
@@ -11,18 +11,19 @@ Description:
 
 Options:
 
-  -h, --help                        - Show this help.                                              
-  -a, --assignee     <assignee>     - Assign the issue to 'self' or someone (by username or name)  
-  --due-date         <dueDate>      - Due date of the issue                                        
-  -p, --parent       <parent>       - Parent issue (if any) as a team_number code                  
-  --priority         <priority>     - Priority of the issue (1-4, descending priority)             
-  --estimate         <estimate>     - Points estimate of the issue                                 
-  -d, --description  <description>  - Description of the issue                                     
-  -l, --label        <label>        - Issue label associated with the issue. May be repeated.      
-  --team             <team>         - Team associated with the issue (if not your default team)    
-  --project          <project>      - Name of the project with the issue                           
-  -s, --state        <state>        - Workflow state for the issue (by name or type)               
-  -t, --title        <title>        - Title of the issue                                           
+  -h, --help                         - Show this help.                                                
+  -a, --assignee      <assignee>     - Assign the issue to 'self' or someone (by username or name)    
+  --due-date          <dueDate>      - Due date of the issue                                          
+  -p, --parent        <parent>       - Parent issue (if any) as a team_number code                    
+  --priority          <priority>     - Priority of the issue (1-4, descending priority)               
+  --estimate          <estimate>     - Points estimate of the issue                                   
+  -d, --description   <description>  - Description of the issue                                       
+  --description-file  <path>         - Read description from a file (preferred for markdown content)  
+  -l, --label         <label>        - Issue label associated with the issue. May be repeated.        
+  --team              <team>         - Team associated with the issue (if not your default team)      
+  --project           <project>      - Name of the project with the issue                             
+  -s, --state         <state>        - Workflow state for the issue (by name or type)                 
+  -t, --title         <title>        - Title of the issue                                             
 
 "
 stderr:


### PR DESCRIPTION
Add file-based flags for markdown content in issue and comment commands

- Add --description-file flag to issue create/update commands
- Add --body-file flag to comment add/update commands
- Update skill template with best practices for using file-based flags
- Validate that inline and file-based flags are not used together
- Provide helpful error messages for file reading failures

Fixes #133