### PR TITLE
Add --all-teams flag to issue list command

### DIFF
--- a/skills/linear-cli/references/issue.md
+++ b/skills/linear-cli/references/issue.md
@@ -80,6 +80,7 @@ Options:
   -U, --unassigned                 - Show only unassigned issues                                                                                                  
   --sort               <sort>      - Sort order (can also be set via LINEAR_ISSUE_SORT)                    (Values: "manual", "priority")                         
   --team               <team>      - Team to list issues for (if not your default team)                                                                           
+  --all-teams                      - Show issues from all teams in the workspace                                                                                  
   --project            <project>   - Filter by project name                                                                                                       
   --limit              <limit>     - Maximum number of issues to fetch (default: 50, use 0 for unlimited)  (Default: 50)                                          
   -w, --web                        - Open in web browser                                                                                                          

--- a/src/utils/linear.ts
+++ b/src/utils/linear.ts
@@ -389,7 +389,7 @@ export async function fetchParentIssueData(parentId: string): Promise<
 }
 
 export async function fetchIssuesForState(
-  teamKey: string,
+  teamKey: string | undefined,
   state: string[] | undefined,
   assignee?: string,
   unassigned = false,
@@ -410,8 +410,10 @@ export async function fetchIssuesForState(
     )
   }
 
-  const filter: IssueFilter = {
-    team: { key: { eq: teamKey } },
+  const filter: IssueFilter = {}
+
+  if (teamKey) {
+    filter.team = { key: { eq: teamKey } }
   }
 
   if (state) {

--- a/test/commands/issue/__snapshots__/issue-list.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-list.test.ts.snap
@@ -20,6 +20,7 @@ Options:
   -U, --unassigned                 - Show only unassigned issues                                                                                                  
   --sort               <sort>      - Sort order (can also be set via LINEAR_ISSUE_SORT)                    (Values: \\x1b[32m"manual"\\x1b[39m, \\x1b[32m"priority"\\x1b[39m)                         
   --team               <team>      - Team to list issues for (if not your default team)                                                                           
+  --all-teams                      - Show issues from all teams in the workspace                                                                                  
   --project            <project>   - Filter by project name                                                                                                       
   --limit              <limit>     - Maximum number of issues to fetch (default: 50, use 0 for unlimited)  (Default: \\x1b[33m50\\x1b[39m)                                          
   -w, --web                        - Open in web browser                                                                                                          
@@ -27,6 +28,17 @@ Options:
   --no-pager                       - Disable automatic paging for long output                                                                                     
 
 '
+stderr:
+""
+`;
+
+snapshot[`Issue List Command - All Teams 1`] = `
+stdout:
+"◌   ID           TITLE                  LABELS  E STATE       UPDATED     
+⚠⚠⚠ BACKEND-123  Fix authentication bug bug     3 In Progress 759 days ago
+▄▆█ FRONTEND-456 Update user interface  feature 5 To Do       760 days ago
+--- SEC-789      Security audit review          - Backlog     761 days ago
+"
 stderr:
 ""
 `;

--- a/test/commands/issue/issue-list.test.ts
+++ b/test/commands/issue/issue-list.test.ts
@@ -1,6 +1,7 @@
 import { snapshotTest } from "@cliffy/testing"
 import { listCommand } from "../../../src/commands/issue/issue-list.ts"
 import { commonDenoArgs } from "../../utils/test-helpers.ts"
+import { MockLinearServer } from "../../utils/mock_linear_server.ts"
 
 // Test help output
 await snapshotTest({
@@ -11,5 +12,112 @@ await snapshotTest({
   denoArgs: commonDenoArgs,
   async fn() {
     await listCommand.parse()
+  },
+})
+
+// Test --all-teams flag
+await snapshotTest({
+  name: "Issue List Command - All Teams",
+  meta: import.meta,
+  colors: false,
+  args: ["--all-teams", "--no-pager", "--sort", "manual"],
+  denoArgs: commonDenoArgs,
+  async fn() {
+    const server = new MockLinearServer([
+      {
+        queryName: "GetIssuesForState",
+        response: {
+          data: {
+            issues: {
+              nodes: [
+                {
+                  id: "issue-1",
+                  identifier: "BACKEND-123",
+                  title: "Fix authentication bug",
+                  priority: 1,
+                  estimate: 3,
+                  assignee: {
+                    initials: "JD",
+                  },
+                  state: {
+                    id: "state-1",
+                    name: "In Progress",
+                    color: "#3b82f6",
+                  },
+                  labels: {
+                    nodes: [
+                      {
+                        id: "label-1",
+                        name: "bug",
+                        color: "#ef4444",
+                      },
+                    ],
+                  },
+                  updatedAt: "2024-01-15T10:00:00Z",
+                },
+                {
+                  id: "issue-2",
+                  identifier: "FRONTEND-456",
+                  title: "Update user interface",
+                  priority: 2,
+                  estimate: 5,
+                  assignee: {
+                    initials: "AS",
+                  },
+                  state: {
+                    id: "state-2",
+                    name: "To Do",
+                    color: "#6b7280",
+                  },
+                  labels: {
+                    nodes: [
+                      {
+                        id: "label-2",
+                        name: "feature",
+                        color: "#10b981",
+                      },
+                    ],
+                  },
+                  updatedAt: "2024-01-14T14:30:00Z",
+                },
+                {
+                  id: "issue-3",
+                  identifier: "SEC-789",
+                  title: "Security audit review",
+                  priority: 0,
+                  estimate: null,
+                  assignee: null,
+                  state: {
+                    id: "state-3",
+                    name: "Backlog",
+                    color: "#94a3b8",
+                  },
+                  labels: {
+                    nodes: [],
+                  },
+                  updatedAt: "2024-01-13T09:15:00Z",
+                },
+              ],
+              pageInfo: {
+                hasNextPage: false,
+                endCursor: null,
+              },
+            },
+          },
+        },
+      },
+    ])
+
+    try {
+      await server.start()
+      Deno.env.set("LINEAR_GRAPHQL_ENDPOINT", server.getEndpoint())
+      Deno.env.set("LINEAR_API_KEY", "Bearer test-token")
+
+      await listCommand.parse()
+    } finally {
+      await server.stop()
+      Deno.env.delete("LINEAR_GRAPHQL_ENDPOINT")
+      Deno.env.delete("LINEAR_API_KEY")
+    }
   },
 })


### PR DESCRIPTION
Add --all-teams flag to issue list command

Implements GitHub issue #140 by adding an --all-teams flag to the 
'linear issue list' command that allows querying issues across all 
teams in the workspace without needing to know team keys in advance.

The flag:
- Fetches all teams in the workspace using the existing getAllTeams() function
- Iterates through each team to collect issues
- Combines and sorts results according to the specified sort order
- Validates that --all-teams cannot be used with --team
- Is consistent with existing --all-states and --all-assignees flags

This is especially useful for AI agents and automation that need a 
complete view of the workspace backlog.