### PR TITLE
fix: add proper error checking for git commands

### DIFF
--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,10 +1,22 @@
 import { basename } from "@std/path"
+import { CliError } from "./errors.ts"
 
 export async function getCurrentBranch(): Promise<string | null> {
   const process = new Deno.Command("git", {
     args: ["symbolic-ref", "--short", "HEAD"],
+    stderr: "piped",
   })
-  const { stdout } = await process.output()
+  const { success, stdout, stderr } = await process.output()
+
+  if (!success) {
+    const errorMsg = new TextDecoder().decode(stderr).trim()
+    // Handle detached HEAD state gracefully - this is not necessarily an error
+    if (errorMsg.includes("not a symbolic ref")) {
+      return null
+    }
+    throw new CliError(`Failed to get current branch: ${errorMsg}`)
+  }
+
   const branch = new TextDecoder().decode(stdout).trim()
   return branch || null
 }
@@ -12,8 +24,15 @@ export async function getCurrentBranch(): Promise<string | null> {
 export async function getRepoDir(): Promise<string> {
   const process = new Deno.Command("git", {
     args: ["rev-parse", "--show-toplevel"],
+    stderr: "piped",
   })
-  const { stdout } = await process.output()
+  const { success, stdout, stderr } = await process.output()
+
+  if (!success) {
+    const errorMsg = new TextDecoder().decode(stderr).trim()
+    throw new CliError(`Failed to get repository directory: ${errorMsg}`)
+  }
+
   const fullPath = new TextDecoder().decode(stdout).trim()
   return basename(fullPath)
 }

--- a/test/utils/git.test.ts
+++ b/test/utils/git.test.ts
@@ -1,0 +1,83 @@
+import { assertEquals, assertRejects } from "@std/assert"
+import { getCurrentBranch, getRepoDir } from "../../src/utils/git.ts"
+import { CliError } from "../../src/utils/errors.ts"
+
+Deno.test("getCurrentBranch - handles errors when not in a git repository", async () => {
+  // Create a temporary directory that's not a git repo
+  const tempDir = await Deno.makeTempDir()
+  const originalCwd = Deno.cwd()
+
+  try {
+    Deno.chdir(tempDir)
+    await assertRejects(
+      async () => await getCurrentBranch(),
+      CliError,
+      "Failed to get current branch",
+    )
+  } finally {
+    Deno.chdir(originalCwd)
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})
+
+Deno.test("getRepoDir - handles errors when not in a git repository", async () => {
+  // Create a temporary directory that's not a git repo
+  const tempDir = await Deno.makeTempDir()
+  const originalCwd = Deno.cwd()
+
+  try {
+    Deno.chdir(tempDir)
+    await assertRejects(
+      async () => await getRepoDir(),
+      CliError,
+      "Failed to get repository directory",
+    )
+  } finally {
+    Deno.chdir(originalCwd)
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})
+
+Deno.test("getCurrentBranch - returns null for detached HEAD", async () => {
+  // Create a temporary git repository
+  const tempDir = await Deno.makeTempDir()
+  const originalCwd = Deno.cwd()
+
+  try {
+    Deno.chdir(tempDir)
+
+    // Initialize git repo
+    await new Deno.Command("git", { args: ["init"] }).output()
+    await new Deno.Command("git", {
+      args: ["config", "user.email", "test@example.com"],
+    }).output()
+    await new Deno.Command("git", {
+      args: ["config", "user.name", "Test User"],
+    }).output()
+
+    // Create a commit
+    await Deno.writeTextFile("test.txt", "test")
+    await new Deno.Command("git", { args: ["add", "test.txt"] }).output()
+    await new Deno.Command("git", {
+      args: ["commit", "-m", "initial commit"],
+    }).output()
+
+    // Get the commit hash
+    const { stdout } = await new Deno.Command("git", {
+      args: ["rev-parse", "HEAD"],
+    }).output()
+    const commitHash = new TextDecoder().decode(stdout).trim()
+
+    // Checkout the commit to create detached HEAD
+    await new Deno.Command("git", {
+      args: ["checkout", commitHash],
+    }).output()
+
+    // getCurrentBranch should return null for detached HEAD
+    const branch = await getCurrentBranch()
+    assertEquals(branch, null)
+  } finally {
+    Deno.chdir(originalCwd)
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})

--- a/test/utils/vcs.test.ts
+++ b/test/utils/vcs.test.ts
@@ -1,0 +1,187 @@
+import { assertEquals, assertRejects } from "@std/assert"
+import { getCurrentIssueFromVcs, startVcsWork } from "../../src/utils/vcs.ts"
+import { CliError } from "../../src/utils/errors.ts"
+
+Deno.test("getCurrentIssueFromVcs - handles git errors gracefully", async () => {
+  // Create a temporary directory that's not a git repo
+  const tempDir = await Deno.makeTempDir()
+  const originalCwd = Deno.cwd()
+  const originalVcs = Deno.env.get("LINEAR_VCS")
+
+  try {
+    // Explicitly set VCS to git for this test
+    Deno.env.set("LINEAR_VCS", "git")
+    Deno.chdir(tempDir)
+    await assertRejects(
+      async () => await getCurrentIssueFromVcs(),
+      CliError,
+      "Failed to get current branch",
+    )
+  } finally {
+    Deno.chdir(originalCwd)
+    if (originalVcs !== undefined) {
+      Deno.env.set("LINEAR_VCS", originalVcs)
+    } else {
+      Deno.env.delete("LINEAR_VCS")
+    }
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})
+
+Deno.test("getCurrentIssueFromVcs - extracts issue ID from git branch", async () => {
+  // Create a temporary git repository
+  const tempDir = await Deno.makeTempDir()
+  const originalCwd = Deno.cwd()
+  const originalVcs = Deno.env.get("LINEAR_VCS")
+
+  try {
+    // Explicitly set VCS to git for this test
+    Deno.env.set("LINEAR_VCS", "git")
+    Deno.chdir(tempDir)
+
+    // Initialize git repo
+    await new Deno.Command("git", { args: ["init"] }).output()
+    await new Deno.Command("git", {
+      args: ["config", "user.email", "test@example.com"],
+    }).output()
+    await new Deno.Command("git", {
+      args: ["config", "user.name", "Test User"],
+    }).output()
+
+    // Create initial commit
+    await Deno.writeTextFile("test.txt", "test")
+    await new Deno.Command("git", { args: ["add", "test.txt"] }).output()
+    await new Deno.Command("git", {
+      args: ["commit", "-m", "initial commit"],
+    }).output()
+
+    // Create a branch with an issue ID
+    await new Deno.Command("git", {
+      args: ["checkout", "-b", "feature/ABC-123-test-feature"],
+    }).output()
+
+    const issueId = await getCurrentIssueFromVcs()
+    assertEquals(issueId, "ABC-123")
+  } finally {
+    Deno.chdir(originalCwd)
+    if (originalVcs !== undefined) {
+      Deno.env.set("LINEAR_VCS", originalVcs)
+    } else {
+      Deno.env.delete("LINEAR_VCS")
+    }
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})
+
+Deno.test("getCurrentIssueFromVcs - returns null for branch without issue ID", async () => {
+  // Create a temporary git repository
+  const tempDir = await Deno.makeTempDir()
+  const originalCwd = Deno.cwd()
+  const originalVcs = Deno.env.get("LINEAR_VCS")
+
+  try {
+    // Explicitly set VCS to git for this test
+    Deno.env.set("LINEAR_VCS", "git")
+    Deno.chdir(tempDir)
+
+    // Initialize git repo
+    await new Deno.Command("git", { args: ["init"] }).output()
+    await new Deno.Command("git", {
+      args: ["config", "user.email", "test@example.com"],
+    }).output()
+    await new Deno.Command("git", {
+      args: ["config", "user.name", "Test User"],
+    }).output()
+
+    // Create initial commit
+    await Deno.writeTextFile("test.txt", "test")
+    await new Deno.Command("git", { args: ["add", "test.txt"] }).output()
+    await new Deno.Command("git", {
+      args: ["commit", "-m", "initial commit"],
+    }).output()
+
+    // Create a branch without an issue ID
+    await new Deno.Command("git", {
+      args: ["checkout", "-b", "main"],
+    }).output()
+
+    const issueId = await getCurrentIssueFromVcs()
+    assertEquals(issueId, null)
+  } finally {
+    Deno.chdir(originalCwd)
+    if (originalVcs !== undefined) {
+      Deno.env.set("LINEAR_VCS", originalVcs)
+    } else {
+      Deno.env.delete("LINEAR_VCS")
+    }
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})
+
+Deno.test("startVcsWork - propagates git checkout errors when not in a git repo", async () => {
+  const tempDir = await Deno.makeTempDir()
+  const originalCwd = Deno.cwd()
+  const originalVcs = Deno.env.get("LINEAR_VCS")
+
+  try {
+    Deno.env.set("LINEAR_VCS", "git")
+    Deno.chdir(tempDir)
+
+    await assertRejects(
+      async () => await startVcsWork("ABC-123", "feature/ABC-123-test"),
+      CliError,
+      "Failed to create branch",
+    )
+  } finally {
+    Deno.chdir(originalCwd)
+    if (originalVcs !== undefined) {
+      Deno.env.set("LINEAR_VCS", originalVcs)
+    } else {
+      Deno.env.delete("LINEAR_VCS")
+    }
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})
+
+Deno.test("startVcsWork - propagates git checkout errors when source ref doesn't exist", async () => {
+  const tempDir = await Deno.makeTempDir()
+  const originalCwd = Deno.cwd()
+  const originalVcs = Deno.env.get("LINEAR_VCS")
+
+  try {
+    Deno.env.set("LINEAR_VCS", "git")
+    Deno.chdir(tempDir)
+
+    // Initialize git repo
+    await new Deno.Command("git", { args: ["init"] }).output()
+    await new Deno.Command("git", {
+      args: ["config", "user.email", "test@example.com"],
+    }).output()
+    await new Deno.Command("git", {
+      args: ["config", "user.name", "Test User"],
+    }).output()
+
+    // Create initial commit
+    await Deno.writeTextFile("test.txt", "test")
+    await new Deno.Command("git", { args: ["add", "test.txt"] }).output()
+    await new Deno.Command("git", {
+      args: ["commit", "-m", "initial commit"],
+    }).output()
+
+    // Try to create a branch from a non-existent ref
+    await assertRejects(
+      async () =>
+        await startVcsWork("ABC-123", "feature/ABC-123-test", "nonexistent"),
+      CliError,
+      "Failed to create branch",
+    )
+  } finally {
+    Deno.chdir(originalCwd)
+    if (originalVcs !== undefined) {
+      Deno.env.set("LINEAR_VCS", originalVcs)
+    } else {
+      Deno.env.delete("LINEAR_VCS")
+    }
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})


### PR DESCRIPTION
fix: add proper error checking for git commands

- Add error handling to git utility functions (getCurrentBranch, getRepoDir)
- Add error checking to all git checkout commands in vcs.ts
- Handle detached HEAD state gracefully in getCurrentBranch
- Add comprehensive tests for git error scenarios
- Tests verify errors are thrown with descriptive messages
- Tests verify detached HEAD returns null instead of throwing

Fixes #62