### PR TITLE
fix: correct API key creation URL in auth login

### DIFF
--- a/src/commands/auth/auth-login.ts
+++ b/src/commands/auth/auth-login.ts
@@ -45,7 +45,8 @@ export const loginCommand = new Command()
 
       if (!apiKey) {
         throw new ValidationError("No API key provided", {
-          suggestion: "Create one at https://linear.app/settings/account/security",
+          suggestion:
+            "Create one at https://linear.app/settings/account/security",
         })
       }
 


### PR DESCRIPTION
## Summary

- Replace incorrect URL `https://linear.app/settings/api` with `https://linear.app/settings/account/security` in the `auth login` command prompt and error message
- The old URL isn't the correct one where you can create those API keys. The new one correctly redirects to the API key management page.

## Test plan

- `deno task check` isn't passing due to pre-existing failures on `main`
- [x] `deno lint` passes
- [x] `deno task dev auth login` shows the corrected URL in the prompt hint


## Test evidence:
<img width="759" height="134" alt="CleanShot 2026-02-16 at 17 05 16" src="https://github.com/user-attachments/assets/a8d7813b-f609-4599-93f5-cc9a20e71bad" />