### PR TITLE
feat: add cycle support to issue commands

### DIFF
--- a/skills/linear-cli/references/issue.md
+++ b/skills/linear-cli/references/issue.md
@@ -280,6 +280,7 @@ Options:
   --project                  <project>      - Name of the project with the issue                             
   -s, --state                <state>        - Workflow state for the issue (by name or type)                 
   --milestone                <milestone>    - Name of the project milestone                                  
+  --cycle                    <cycle>        - Cycle name, number, or 'active'                                
   --no-use-default-template                 - Do not use default template for the issue                      
   --no-interactive                          - Disable interactive prompts                                    
   -t, --title                <title>        - Title of the issue
@@ -313,6 +314,7 @@ Options:
   --project           <project>      - Name of the project with the issue                             
   -s, --state         <state>        - Workflow state for the issue (by name or type)                 
   --milestone         <milestone>    - Name of the project milestone                                  
+  --cycle             <cycle>        - Cycle name, number, or 'active'                                
   -t, --title         <title>        - Title of the issue
 ```
 

--- a/src/commands/issue/issue-create.ts
+++ b/src/commands/issue/issue-create.ts
@@ -7,6 +7,7 @@ import { getPriorityDisplay } from "../../utils/display.ts"
 import {
   fetchParentIssueData,
   getAllTeams,
+  getCycleIdByNameOrNumber,
   getIssueId,
   getIssueIdentifier,
   getIssueLabelIdByNameForTeam,
@@ -500,6 +501,10 @@ export const createCommand = new Command()
     "Name of the project milestone",
   )
   .option(
+    "--cycle <cycle:string>",
+    "Cycle name, number, or 'active'",
+  )
+  .option(
     "--no-use-default-template",
     "Do not use default template for the issue",
   )
@@ -522,6 +527,7 @@ export const createCommand = new Command()
         project,
         state,
         milestone,
+        cycle,
         interactive,
         title,
       },
@@ -556,7 +562,7 @@ export const createCommand = new Command()
       const noFlagsProvided = !title && !assignee && !dueDate &&
         priority === undefined && estimate === undefined && !finalDescription &&
         (!labels || labels.length === 0) &&
-        !team && !project && !state && !milestone && !start
+        !team && !project && !state && !milestone && !cycle && !start
 
       if (noFlagsProvided && interactive) {
         try {
@@ -761,6 +767,11 @@ export const createCommand = new Command()
           )
         }
 
+        let cycleId: string | undefined
+        if (cycle != null) {
+          cycleId = await getCycleIdByNameOrNumber(cycle, teamId)
+        }
+
         // Date validation done at graphql level
 
         // Convert parent identifier if provided and fetch parent data
@@ -799,6 +810,7 @@ export const createCommand = new Command()
           teamId: teamId,
           projectId: projectId || parentData?.projectId,
           projectMilestoneId,
+          cycleId,
           stateId,
           useDefaultTemplate,
           description: finalDescription,

--- a/src/commands/issue/issue-update.ts
+++ b/src/commands/issue/issue-update.ts
@@ -2,6 +2,7 @@ import { Command } from "@cliffy/command"
 import { gql } from "../../__codegen__/gql.ts"
 import { getGraphQLClient } from "../../utils/graphql.ts"
 import {
+  getCycleIdByNameOrNumber,
   getIssueId,
   getIssueIdentifier,
   getIssueLabelIdByNameForTeam,
@@ -72,6 +73,10 @@ export const updateCommand = new Command()
     "--milestone <milestone:string>",
     "Name of the project milestone",
   )
+  .option(
+    "--cycle <cycle:string>",
+    "Cycle name, number, or 'active'",
+  )
   .option("-t, --title <title:string>", "Title of the issue")
   .action(
     async (
@@ -88,6 +93,7 @@ export const updateCommand = new Command()
         project,
         state,
         milestone,
+        cycle,
         title,
       },
       issueIdArg,
@@ -213,6 +219,11 @@ export const updateCommand = new Command()
           )
         }
 
+        let cycleId: string | undefined
+        if (cycle != null) {
+          cycleId = await getCycleIdByNameOrNumber(cycle, teamId)
+        }
+
         // Build the update input object, only including fields that were provided
         const input: Record<string, string | number | string[] | undefined> = {}
 
@@ -241,6 +252,7 @@ export const updateCommand = new Command()
         if (projectMilestoneId !== undefined) {
           input.projectMilestoneId = projectMilestoneId
         }
+        if (cycleId !== undefined) input.cycleId = cycleId
         if (stateId !== undefined) input.stateId = stateId
 
         spinner?.stop()

--- a/src/commands/issue/issue-view.ts
+++ b/src/commands/issue/issue-view.ts
@@ -126,6 +126,11 @@ export const viewCommand = new Command()
       if (issueData.projectMilestone) {
         metaParts.push(`**Milestone:** ${issueData.projectMilestone.name}`)
       }
+      if (issueData.cycle) {
+        const cycleName = issueData.cycle.name ??
+          `Cycle ${issueData.cycle.number}`
+        metaParts.push(`**Cycle:** ${cycleName}`)
+      }
       const metaLine = metaParts.length > 0
         ? "\n\n" + metaParts.join(" | ")
         : ""

--- a/test/commands/issue/__snapshots__/issue-create.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-create.test.ts.snap
@@ -25,6 +25,7 @@ Options:
   --project                  <project>      - Name of the project with the issue                             
   -s, --state                <state>        - Workflow state for the issue (by name or type)                 
   --milestone                <milestone>    - Name of the project milestone                                  
+  --cycle                    <cycle>        - Cycle name, number, or 'active'                                
   --no-use-default-template                 - Do not use default template for the issue                      
   --no-interactive                          - Disable interactive prompts                                    
   -t, --title                <title>        - Title of the issue                                             
@@ -59,6 +60,16 @@ stdout:
 "Creating issue in ENG
 
 https://linear.app/test-team/issue/ENG-456/test-case-insensitive-labels
+"
+stderr:
+""
+`;
+
+snapshot[`Issue Create Command - With Cycle 1`] = `
+stdout:
+"Creating issue in ENG
+
+https://linear.app/test-team/issue/ENG-890/test-cycle-feature
 "
 stderr:
 ""

--- a/test/commands/issue/__snapshots__/issue-update.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-update.test.ts.snap
@@ -24,6 +24,7 @@ Options:
   --project           <project>      - Name of the project with the issue                             
   -s, --state         <state>        - Workflow state for the issue (by name or type)                 
   --milestone         <milestone>    - Name of the project milestone                                  
+  --cycle             <cycle>        - Cycle name, number, or 'active'                                
   -t, --title         <title>        - Title of the issue                                             
 
 "
@@ -54,6 +55,17 @@ stderr:
 `;
 
 snapshot[`Issue Update Command - Case Insensitive Label Matching 1`] = `
+stdout:
+"Updating issue ENG-123
+
+✓ Updated issue ENG-123: Test Issue
+https://linear.app/test-team/issue/ENG-123/test-issue
+"
+stderr:
+""
+`;
+
+snapshot[`Issue Update Command - With Cycle 1`] = `
 stdout:
 "Updating issue ENG-123
 

--- a/test/commands/issue/__snapshots__/issue-view.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-view.test.ts.snap
@@ -197,3 +197,15 @@ Set up Datadog dashboards for the new service.
 stderr:
 ""
 `;
+
+snapshot[`Issue View Command - With Cycle 1`] = `
+stdout:
+"# TEST-890: Implement rate limiting
+
+**Project:** API Gateway v2 | **Cycle:** Sprint 7
+
+Add rate limiting to the API gateway.
+"
+stderr:
+""
+`;


### PR DESCRIPTION
## Summary
- Add `--cycle` flag to `issue create` and `issue update` commands, accepting cycle name, number, or `active` keyword
- Display cycle in `issue view` output alongside project and milestone metadata
- New `getCycleIdByNameOrNumber` helper queries team cycles via GraphQL

## Test plan
- [x] 208 tests passing (3 new snapshot tests for cycle in create/update/view)
- [x] `deno check`, `deno lint` clean
- [x] Manual: `linear issue update PLA4-10034 --team PLA4 --cycle active` — verified cycle set via `issue view`

🤖 Generated with [Claude Code](https://claude.com/claude-code)