### PR TITLE
fix: correct success message order for 'blocked-by' relation

### DIFF
--- a/src/commands/issue/issue-relation.ts
+++ b/src/commands/issue/issue-relation.ts
@@ -117,9 +117,6 @@ const addRelationCommand = new Command()
             success
             issueRelation {
               id
-              type
-              issue { identifier }
-              relatedIssue { identifier }
             }
           }
         }
@@ -140,10 +137,9 @@ const addRelationCommand = new Command()
         throw new Error("Failed to create relation")
       }
 
-      const relation = data.issueRelationCreate.issueRelation
-      if (relation) {
+      if (data.issueRelationCreate.issueRelation) {
         console.log(
-          `✓ Created relation: ${relation.issue.identifier} ${relationType} ${relation.relatedIssue.identifier}`,
+          `✓ Created relation: ${issueIdentifier} ${relationType} ${relatedIssueIdentifier}`,
         )
       }
     } catch (error) {

--- a/test/commands/issue/__snapshots__/issue-relation.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-relation.test.ts.snap
@@ -1,0 +1,42 @@
+export const snapshot = {};
+
+snapshot[`Issue Relation Add Command - Help Text 1`] = `
+stdout:
+"
+Usage: relation add <issueId> <relationType> <relatedIssueId>
+
+Description:
+
+  Add a relation between two issues
+
+Options:
+
+  -h, --help  - Show this help.  
+
+Examples:
+
+  Mark issue as blocked by another linear issue relation add ENG-123 blocked-by ENG-100
+  Mark issue as blocking another   linear issue relation add ENG-123 blocks ENG-456    
+  Mark issues as related           linear issue relation add ENG-123 related ENG-456   
+  Mark issue as duplicate          linear issue relation add ENG-123 duplicate ENG-100 
+
+"
+stderr:
+""
+`;
+
+snapshot[`Issue Relation Add Command - blocks 1`] = `
+stdout:
+"✓ Created relation: ENG-123 blocks ENG-456
+"
+stderr:
+""
+`;
+
+snapshot[`Issue Relation Add Command - blocked-by shows correct order 1`] = `
+stdout:
+"✓ Created relation: ENG-123 blocked-by ENG-456
+"
+stderr:
+""
+`;

--- a/test/commands/issue/issue-relation.test.ts
+++ b/test/commands/issue/issue-relation.test.ts
@@ -1,0 +1,109 @@
+import { snapshotTest } from "@cliffy/testing"
+import { relationCommand } from "../../../src/commands/issue/issue-relation.ts"
+import {
+  commonDenoArgs,
+  setupMockLinearServer,
+} from "../../utils/test-helpers.ts"
+
+// Test help output
+await snapshotTest({
+  name: "Issue Relation Add Command - Help Text",
+  meta: import.meta,
+  colors: false,
+  args: ["add", "--help"],
+  denoArgs: commonDenoArgs,
+  async fn() {
+    await relationCommand.parse()
+  },
+})
+
+// Test: relation add with "blocks" - success message shows original order
+await snapshotTest({
+  name: "Issue Relation Add Command - blocks",
+  meta: import.meta,
+  colors: false,
+  args: ["add", "ENG-123", "blocks", "ENG-456"],
+  denoArgs: commonDenoArgs,
+  async fn() {
+    const { cleanup } = await setupMockLinearServer([
+      {
+        queryName: "GetIssueId",
+        variables: { id: "ENG-123" },
+        response: {
+          data: { issue: { id: "issue-id-123" } },
+        },
+      },
+      {
+        queryName: "GetIssueId",
+        variables: { id: "ENG-456" },
+        response: {
+          data: { issue: { id: "issue-id-456" } },
+        },
+      },
+      {
+        queryName: "CreateIssueRelation",
+        response: {
+          data: {
+            issueRelationCreate: {
+              success: true,
+              issueRelation: { id: "relation-id-1" },
+            },
+          },
+        },
+      },
+    ])
+
+    try {
+      await relationCommand.parse()
+    } finally {
+      await cleanup()
+    }
+  },
+})
+
+// Test: relation add with "blocked-by" - success message should show original user-specified order
+// i.e. "ENG-123 blocked-by ENG-456" NOT "ENG-456 blocked-by ENG-123"
+await snapshotTest({
+  name: "Issue Relation Add Command - blocked-by shows correct order",
+  meta: import.meta,
+  colors: false,
+  args: ["add", "ENG-123", "blocked-by", "ENG-456"],
+  denoArgs: commonDenoArgs,
+  async fn() {
+    const { cleanup } = await setupMockLinearServer([
+      {
+        queryName: "GetIssueId",
+        variables: { id: "ENG-123" },
+        response: {
+          data: { issue: { id: "issue-id-123" } },
+        },
+      },
+      {
+        queryName: "GetIssueId",
+        variables: { id: "ENG-456" },
+        response: {
+          data: { issue: { id: "issue-id-456" } },
+        },
+      },
+      {
+        queryName: "CreateIssueRelation",
+        response: {
+          data: {
+            issueRelationCreate: {
+              success: true,
+              // API is called with swapped IDs (ENG-456 blocks ENG-123),
+              // but we should display the user-specified order in the message
+              issueRelation: { id: "relation-id-2" },
+            },
+          },
+        },
+      },
+    ])
+
+    try {
+      await relationCommand.parse()
+    } finally {
+      await cleanup()
+    }
+  },
+})


### PR DESCRIPTION
fix: correct success message order for 'blocked-by' relation

When using 'relation add X blocked-by Y', the API is called with swapped
IDs (Y blocks X), but the success message was showing the API's returned
identifiers (in the swapped order) instead of the user-specified order.

Fixes: the message now uses the original issueIdentifier and
relatedIssueIdentifier variables, so 'relation add ENG-123 blocked-by ENG-456'
correctly shows '✓ Created relation: ENG-123 blocked-by ENG-456'.

Closes #152