### PR TITLE
fix: fall back to slugId match when --project name lookup fails

### DIFF
--- a/skills/linear-cli/references/issue.md
+++ b/skills/linear-cli/references/issue.md
@@ -277,7 +277,7 @@ Options:
   --description-file         <path>         - Read description from a file (preferred for markdown content)  
   -l, --label                <label>        - Issue label associated with the issue. May be repeated.        
   --team                     <team>         - Team associated with the issue (if not your default team)      
-  --project                  <project>      - Name of the project with the issue                             
+  --project                  <project>      - Name or slug ID of the project with the issue                  
   -s, --state                <state>        - Workflow state for the issue (by name or type)                 
   --milestone                <milestone>    - Name of the project milestone                                  
   --cycle                    <cycle>        - Cycle name, number, or 'active'                                
@@ -311,7 +311,7 @@ Options:
   --description-file  <path>         - Read description from a file (preferred for markdown content)  
   -l, --label         <label>        - Issue label associated with the issue. May be repeated.        
   --team              <team>         - Team associated with the issue (if not your default team)      
-  --project           <project>      - Name of the project with the issue                             
+  --project           <project>      - Name or slug ID of the project with the issue                  
   -s, --state         <state>        - Workflow state for the issue (by name or type)                 
   --milestone         <milestone>    - Name of the project milestone                                  
   --cycle             <cycle>        - Cycle name, number, or 'active'                                

--- a/src/commands/issue/issue-create.ts
+++ b/src/commands/issue/issue-create.ts
@@ -490,7 +490,7 @@ export const createCommand = new Command()
   )
   .option(
     "--project <project:string>",
-    "Name of the project with the issue",
+    "Name or slug ID of the project with the issue",
   )
   .option(
     "-s, --state <state:string>",

--- a/src/commands/issue/issue-update.ts
+++ b/src/commands/issue/issue-update.ts
@@ -63,7 +63,7 @@ export const updateCommand = new Command()
   )
   .option(
     "--project <project:string>",
-    "Name of the project with the issue",
+    "Name or slug ID of the project with the issue",
   )
   .option(
     "-s, --state <state:string>",

--- a/src/utils/linear.ts
+++ b/src/utils/linear.ts
@@ -563,7 +563,24 @@ export async function getProjectIdByName(
     }
   `)
   const data = await client.request(query, { name })
-  return data.projects?.nodes[0]?.id
+  const projectId = data.projects?.nodes[0]?.id
+  if (projectId) return projectId
+
+  // Fall back to matching by slugId (the 12-char hex string visible in
+  // `project list` output and Linear URLs). This provides a reliable
+  // alternative when project names contain special characters that the
+  // exact-match name filter doesn't handle well.
+  const slugQuery = gql(/* GraphQL */ `
+    query GetProjectIdBySlugId($slugId: String!) {
+      projects(filter: { slugId: { eq: $slugId } }) {
+        nodes {
+          id
+        }
+      }
+    }
+  `)
+  const slugData = await client.request(slugQuery, { slugId: name })
+  return slugData.projects?.nodes[0]?.id
 }
 
 export async function resolveProjectId(

--- a/test/commands/issue/__snapshots__/issue-create.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-create.test.ts.snap
@@ -22,7 +22,7 @@ Options:
   --description-file         <path>         - Read description from a file (preferred for markdown content)  
   -l, --label                <label>        - Issue label associated with the issue. May be repeated.        
   --team                     <team>         - Team associated with the issue (if not your default team)      
-  --project                  <project>      - Name of the project with the issue                             
+  --project                  <project>      - Name or slug ID of the project with the issue                  
   -s, --state                <state>        - Workflow state for the issue (by name or type)                 
   --milestone                <milestone>    - Name of the project milestone                                  
   --cycle                    <cycle>        - Cycle name, number, or 'active'                                

--- a/test/commands/issue/__snapshots__/issue-update.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-update.test.ts.snap
@@ -21,7 +21,7 @@ Options:
   --description-file  <path>         - Read description from a file (preferred for markdown content)  
   -l, --label         <label>        - Issue label associated with the issue. May be repeated.        
   --team              <team>         - Team associated with the issue (if not your default team)      
-  --project           <project>      - Name of the project with the issue                             
+  --project           <project>      - Name or slug ID of the project with the issue                  
   -s, --state         <state>        - Workflow state for the issue (by name or type)                 
   --milestone         <milestone>    - Name of the project milestone                                  
   --cycle             <cycle>        - Cycle name, number, or 'active'                                


### PR DESCRIPTION
I hit an issue when using amp to create tickets under a project that contained special characters in its name. Here's its summary of the problem & the fix.

I've verified that creating tickets via a project slug works using this code:

## Problem

The `--project` flag on `issue create` fails to match projects whose names contain special characters. For example, a project named `'B-Site' (Tiger Team)` (with Unicode curly quotes) can't be matched when the user passes straight quotes from their terminal.

The root cause is that `getProjectIdByName` uses `{ name: { eq: $name } }` which does a byte-exact match. In `--no-interactive` mode, the `containsIgnoreCase` fuzzy fallback is skipped entirely, so there's no recovery path.

## Investigation

We tested the available GraphQL `StringComparator` filters:

- `eq` — fails due to Unicode mismatch (e.g. `'` vs `'`)
- `eqIgnoreCase` — also fails (same Unicode issue, it only ignores ASCII case)
- `containsIgnoreCase` — works server-side (Linear does some Unicode normalisation) but returns substring matches, so we can't use it as a drop-in replacement without risking false positives. A client-side exact-match filter after `containsIgnoreCase` would also fail because we can't replicate Linear's normalisation locally.

## Fix

If the exact `eq` name match returns no results, fall back to matching by `slugId` — the 12-character hex string visible in `project list` output and Linear URLs (e.g. `linear.app/org/project/b-site-tiger-team-7845e43b997f`).

This gives users a reliable way to specify projects with problematic names:

```bash
linear issue create --team MYTEAM --project 7845e43b997f --title "my issue" --no-interactive
```
