### PR TITLE
test: add issue update -p priority test and regenerate skill docs

### DIFF
--- a/skills/linear-cli/references/issue.md
+++ b/skills/linear-cli/references/issue.md
@@ -270,8 +270,8 @@ Options:
   --start                                   - Start the issue after creation                                 
   -a, --assignee             <assignee>     - Assign the issue to 'self' or someone (by username or name)    
   --due-date                 <dueDate>      - Due date of the issue                                          
-  -p, --parent               <parent>       - Parent issue (if any) as a team_number code                    
-  --priority                 <priority>     - Priority of the issue (1-4, descending priority)               
+  --parent                   <parent>       - Parent issue (if any) as a team_number code                    
+  -p, --priority             <priority>     - Priority of the issue (1-4, descending priority)               
   --estimate                 <estimate>     - Points estimate of the issue                                   
   -d, --description          <description>  - Description of the issue                                       
   --description-file         <path>         - Read description from a file (preferred for markdown content)  
@@ -304,8 +304,8 @@ Options:
   -w, --workspace     <slug>         - Target workspace (uses credentials)                            
   -a, --assignee      <assignee>     - Assign the issue to 'self' or someone (by username or name)    
   --due-date          <dueDate>      - Due date of the issue                                          
-  -p, --parent        <parent>       - Parent issue (if any) as a team_number code                    
-  --priority          <priority>     - Priority of the issue (1-4, descending priority)               
+  --parent            <parent>       - Parent issue (if any) as a team_number code                    
+  -p, --priority      <priority>     - Priority of the issue (1-4, descending priority)               
   --estimate          <estimate>     - Points estimate of the issue                                   
   -d, --description   <description>  - Description of the issue                                       
   --description-file  <path>         - Read description from a file (preferred for markdown content)  

--- a/src/commands/issue/issue-create.ts
+++ b/src/commands/issue/issue-create.ts
@@ -460,11 +460,11 @@ export const createCommand = new Command()
     "Due date of the issue",
   )
   .option(
-    "-p, --parent <parent:string>",
+    "--parent <parent:string>",
     "Parent issue (if any) as a team_number code",
   )
   .option(
-    "--priority <priority:number>",
+    "-p, --priority <priority:number>",
     "Priority of the issue (1-4, descending priority)",
   )
   .option(

--- a/src/commands/issue/issue-update.ts
+++ b/src/commands/issue/issue-update.ts
@@ -33,11 +33,11 @@ export const updateCommand = new Command()
     "Due date of the issue",
   )
   .option(
-    "-p, --parent <parent:string>",
+    "--parent <parent:string>",
     "Parent issue (if any) as a team_number code",
   )
   .option(
-    "--priority <priority:number>",
+    "-p, --priority <priority:number>",
     "Priority of the issue (1-4, descending priority)",
   )
   .option(

--- a/test/commands/issue/__snapshots__/issue-create.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-create.test.ts.snap
@@ -15,8 +15,8 @@ Options:
   --start                                   - Start the issue after creation                                 
   -a, --assignee             <assignee>     - Assign the issue to 'self' or someone (by username or name)    
   --due-date                 <dueDate>      - Due date of the issue                                          
-  -p, --parent               <parent>       - Parent issue (if any) as a team_number code                    
-  --priority                 <priority>     - Priority of the issue (1-4, descending priority)               
+  --parent                   <parent>       - Parent issue (if any) as a team_number code                    
+  -p, --priority             <priority>     - Priority of the issue (1-4, descending priority)               
   --estimate                 <estimate>     - Points estimate of the issue                                   
   -d, --description          <description>  - Description of the issue                                       
   --description-file         <path>         - Read description from a file (preferred for markdown content)  
@@ -60,6 +60,16 @@ stdout:
 "Creating issue in ENG
 
 https://linear.app/test-team/issue/ENG-456/test-case-insensitive-labels
+"
+stderr:
+""
+`;
+
+snapshot[`Issue Create Command - Short Flag -p Is Priority 1`] = `
+stdout:
+"Creating issue in ENG
+
+https://linear.app/test-team/issue/ENG-999/test-priority-flag
 "
 stderr:
 ""

--- a/test/commands/issue/__snapshots__/issue-update.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-update.test.ts.snap
@@ -14,8 +14,8 @@ Options:
   -h, --help                         - Show this help.                                                
   -a, --assignee      <assignee>     - Assign the issue to 'self' or someone (by username or name)    
   --due-date          <dueDate>      - Due date of the issue                                          
-  -p, --parent        <parent>       - Parent issue (if any) as a team_number code                    
-  --priority          <priority>     - Priority of the issue (1-4, descending priority)               
+  --parent            <parent>       - Parent issue (if any) as a team_number code                    
+  -p, --priority      <priority>     - Priority of the issue (1-4, descending priority)               
   --estimate          <estimate>     - Points estimate of the issue                                   
   -d, --description   <description>  - Description of the issue                                       
   --description-file  <path>         - Read description from a file (preferred for markdown content)  
@@ -55,6 +55,17 @@ stderr:
 `;
 
 snapshot[`Issue Update Command - Case Insensitive Label Matching 1`] = `
+stdout:
+"Updating issue ENG-123
+
+✓ Updated issue ENG-123: Test Issue
+https://linear.app/test-team/issue/ENG-123/test-issue
+"
+stderr:
+""
+`;
+
+snapshot[`Issue Update Command - Short Flag -p Is Priority 1`] = `
 stdout:
 "Updating issue ENG-123
 

--- a/test/commands/issue/issue-create.test.ts
+++ b/test/commands/issue/issue-create.test.ts
@@ -260,6 +260,93 @@ await snapshotTest({
   },
 })
 
+// Test that -p is priority (not parent), resolving the flag conflict
+await snapshotTest({
+  name: "Issue Create Command - Short Flag -p Is Priority",
+  meta: import.meta,
+  colors: false,
+  args: [
+    "--title",
+    "Test priority flag",
+    "--team",
+    "ENG",
+    "-p",
+    "2",
+    "--parent",
+    "ENG-220",
+    "--no-interactive",
+  ],
+  denoArgs: commonDenoArgs,
+  async fn() {
+    const { cleanup } = await setupMockLinearServer([
+      // Mock response for getTeamIdByKey()
+      {
+        queryName: "GetTeamIdByKey",
+        variables: { team: "ENG" },
+        response: {
+          data: {
+            teams: {
+              nodes: [{ id: "team-eng-id" }],
+            },
+          },
+        },
+      },
+      // Mock response for getIssueId("ENG-220") - resolves parent identifier to ID
+      {
+        queryName: "GetIssueId",
+        variables: { id: "ENG-220" },
+        response: {
+          data: {
+            issue: {
+              id: "parent-issue-id",
+            },
+          },
+        },
+      },
+      // Mock response for fetchParentIssueData("parent-issue-id")
+      {
+        queryName: "GetParentIssueData",
+        variables: { id: "parent-issue-id" },
+        response: {
+          data: {
+            issue: {
+              title: "Parent Issue",
+              identifier: "ENG-220",
+              project: null,
+            },
+          },
+        },
+      },
+      // Mock response for the create issue mutation
+      {
+        queryName: "CreateIssue",
+        response: {
+          data: {
+            issueCreate: {
+              success: true,
+              issue: {
+                id: "issue-new-priority",
+                identifier: "ENG-999",
+                url:
+                  "https://linear.app/test-team/issue/ENG-999/test-priority-flag",
+                team: {
+                  key: "ENG",
+                },
+              },
+            },
+          },
+        },
+      },
+    ], { LINEAR_TEAM_ID: "ENG" })
+
+    try {
+      await createCommand.parse()
+    } finally {
+      await cleanup()
+    }
+  },
+})
+
 // Test creating an issue with cycle
 await snapshotTest({
   name: "Issue Create Command - With Cycle",

--- a/test/commands/issue/issue-update.test.ts
+++ b/test/commands/issue/issue-update.test.ts
@@ -240,6 +240,72 @@ await snapshotTest({
   },
 })
 
+// Test that -p is priority (not parent), resolving the flag conflict
+await snapshotTest({
+  name: "Issue Update Command - Short Flag -p Is Priority",
+  meta: import.meta,
+  colors: false,
+  args: [
+    "ENG-123",
+    "-p",
+    "2",
+    "--parent",
+    "ENG-220",
+  ],
+  denoArgs: commonDenoArgs,
+  async fn() {
+    const { cleanup } = await setupMockLinearServer([
+      // Mock response for getTeamIdByKey()
+      {
+        queryName: "GetTeamIdByKey",
+        variables: { team: "ENG" },
+        response: {
+          data: {
+            teams: {
+              nodes: [{ id: "team-eng-id" }],
+            },
+          },
+        },
+      },
+      // Mock response for getIssueId("ENG-220") - resolves parent identifier to ID
+      {
+        queryName: "GetIssueId",
+        variables: { id: "ENG-220" },
+        response: {
+          data: {
+            issue: {
+              id: "parent-issue-id",
+            },
+          },
+        },
+      },
+      // Mock response for the update issue mutation
+      {
+        queryName: "UpdateIssue",
+        response: {
+          data: {
+            issueUpdate: {
+              success: true,
+              issue: {
+                id: "issue-existing-123",
+                identifier: "ENG-123",
+                url: "https://linear.app/test-team/issue/ENG-123/test-issue",
+                title: "Test Issue",
+              },
+            },
+          },
+        },
+      },
+    ], { LINEAR_TEAM_ID: "ENG" })
+
+    try {
+      await updateCommand.parse()
+    } finally {
+      await cleanup()
+    }
+  },
+})
+
 // Test updating an issue with cycle
 await snapshotTest({
   name: "Issue Update Command - With Cycle",


### PR DESCRIPTION
test: add issue update -p priority test and regenerate skill docs

- Add snapshot test for 'issue update -p <priority>' to verify -p maps
  to --priority (not --parent), mirroring the fix tested in issue create
- Regenerate skill docs to reflect corrected flag assignments:
  --parent (no short flag) and -p, --priority