### PR TITLE
feat: add comment delete command

### DIFF
--- a/skills/linear-cli/references/issue.md
+++ b/skills/linear-cli/references/issue.md
@@ -338,6 +338,7 @@ Options:
 Commands:
 
   add     [issueId]    - Add a comment to an issue or reply to a comment
+  delete  <commentId>  - Delete a comment                               
   update  <commentId>  - Update an existing comment                     
   list    [issueId]    - List comments for an issue
 ```
@@ -362,6 +363,22 @@ Options:
   --body-file      <path>      - Read comment body from a file (preferred for markdown content)  
   -p, --parent     <id>        - Parent comment ID for replies                                   
   -a, --attach     <filepath>  - Attach a file to the comment (can be used multiple times)
+```
+
+##### delete
+
+```
+Usage:   linear issue comment delete <commentId>
+Version: 1.10.0                                 
+
+Description:
+
+  Delete a comment
+
+Options:
+
+  -h, --help               - Show this help.                      
+  -w, --workspace  <slug>  - Target workspace (uses credentials)
 ```
 
 ##### update

--- a/src/commands/issue/issue-comment-delete.ts
+++ b/src/commands/issue/issue-comment-delete.ts
@@ -1,0 +1,31 @@
+import { Command } from "@cliffy/command"
+import { gql } from "../../__codegen__/gql.ts"
+import { getGraphQLClient } from "../../utils/graphql.ts"
+import { CliError, handleError } from "../../utils/errors.ts"
+
+export const commentDeleteCommand = new Command()
+  .name("delete")
+  .description("Delete a comment")
+  .arguments("<commentId:string>")
+  .action(async (_options, commentId) => {
+    try {
+      const mutation = gql(`
+        mutation DeleteComment($id: String!) {
+          commentDelete(id: $id) {
+            success
+          }
+        }
+      `)
+
+      const client = getGraphQLClient()
+      const data = await client.request(mutation, { id: commentId })
+
+      if (!data.commentDelete.success) {
+        throw new CliError("Failed to delete comment")
+      }
+
+      console.log("✓ Comment deleted")
+    } catch (error) {
+      handleError(error, "Failed to delete comment")
+    }
+  })

--- a/src/commands/issue/issue-comment.ts
+++ b/src/commands/issue/issue-comment.ts
@@ -1,5 +1,6 @@
 import { Command } from "@cliffy/command"
 import { commentAddCommand } from "./issue-comment-add.ts"
+import { commentDeleteCommand } from "./issue-comment-delete.ts"
 import { commentUpdateCommand } from "./issue-comment-update.ts"
 import { commentListCommand } from "./issue-comment-list.ts"
 
@@ -9,5 +10,6 @@ export const commentCommand = new Command()
     this.showHelp()
   })
   .command("add", commentAddCommand)
+  .command("delete", commentDeleteCommand)
   .command("update", commentUpdateCommand)
   .command("list", commentListCommand)

--- a/test/commands/issue/__snapshots__/issue-comment-delete.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-comment-delete.test.ts.snap
@@ -1,0 +1,9 @@
+export const snapshot = {};
+
+snapshot[`Issue Comment Delete Command - Success 1`] = `
+stdout:
+"✓ Comment deleted
+"
+stderr:
+""
+`;

--- a/test/commands/issue/issue-comment-delete.test.ts
+++ b/test/commands/issue/issue-comment-delete.test.ts
@@ -1,0 +1,35 @@
+import { snapshotTest } from "@cliffy/testing"
+import { commentDeleteCommand } from "../../../src/commands/issue/issue-comment-delete.ts"
+import {
+  commonDenoArgs,
+  setupMockLinearServer,
+} from "../../utils/test-helpers.ts"
+
+// Test deleting a comment
+await snapshotTest({
+  name: "Issue Comment Delete Command - Success",
+  meta: import.meta,
+  colors: false,
+  args: ["comment-uuid-123"],
+  denoArgs: commonDenoArgs,
+  async fn() {
+    const { cleanup } = await setupMockLinearServer([
+      {
+        queryName: "DeleteComment",
+        response: {
+          data: {
+            commentDelete: {
+              success: true,
+            },
+          },
+        },
+      },
+    ])
+
+    try {
+      await commentDeleteCommand.parse()
+    } finally {
+      await cleanup()
+    }
+  },
+})


### PR DESCRIPTION
## Summary
- Adds `linear issue comment delete <commentId>` subcommand
- Uses the `commentDelete` GraphQL mutation to delete comments by ID
- Includes snapshot test and updated skill documentation

## Test plan
- [x] `deno check` passes
- [x] `deno task test` passes (214 tests)
- [x] Manually tested: created a comment, deleted it, verified it was removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)