### PR TITLE
feat: add milestone filter to issue list

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ linear issue title     # prints just the issue title
 linear issue url       # prints the Linear.app URL for the issue
 linear issue pr        # creates a GitHub PR with issue details via `gh pr create`
 linear issue list      # list your issues in a table view (supports -s/--state and --sort)
+linear issue list --project "My Project" --milestone "Phase 1"  # filter by milestone
 linear issue list -w   # open issue list in web browser
 linear issue list -a   # open issue list in Linear.app
 linear issue start     # create/switch to issue branch and mark as started

--- a/skills/linear-cli/references/issue.md
+++ b/skills/linear-cli/references/issue.md
@@ -70,22 +70,23 @@ Description:
 
 Options:
 
-  -h, --help                       - Show this help.                                                                                                              
-  -w, --workspace      <slug>      - Target workspace (uses credentials)                                                                                          
-  -s, --state          <state>     - Filter by issue state (can be repeated for multiple states)           (Default: [ "unstarted" ], Values: "triage", "backlog",
-                                                                                                           "unstarted", "started", "completed", "canceled")       
-  --all-states                     - Show issues from all states                                                                                                  
-  --assignee           <assignee>  - Filter by assignee (username)                                                                                                
-  -A, --all-assignees              - Show issues for all assignees                                                                                                
-  -U, --unassigned                 - Show only unassigned issues                                                                                                  
-  --sort               <sort>      - Sort order (can also be set via LINEAR_ISSUE_SORT)                    (Values: "manual", "priority")                         
-  --team               <team>      - Team to list issues for (if not your default team)                                                                           
-  --project            <project>   - Filter by project name                                                                                                       
-  --cycle              <cycle>     - Filter by cycle name, number, or 'active'                                                                                    
-  --limit              <limit>     - Maximum number of issues to fetch (default: 50, use 0 for unlimited)  (Default: 50)                                          
-  -w, --web                        - Open in web browser                                                                                                          
-  -a, --app                        - Open in Linear.app                                                                                                           
-  --no-pager                       - Disable automatic paging for long output
+  -h, --help                        - Show this help.                                                                                                              
+  -w, --workspace      <slug>       - Target workspace (uses credentials)                                                                                          
+  -s, --state          <state>      - Filter by issue state (can be repeated for multiple states)           (Default: [ "unstarted" ], Values: "triage", "backlog",
+                                                                                                            "unstarted", "started", "completed", "canceled")       
+  --all-states                      - Show issues from all states                                                                                                  
+  --assignee           <assignee>   - Filter by assignee (username)                                                                                                
+  -A, --all-assignees               - Show issues for all assignees                                                                                                
+  -U, --unassigned                  - Show only unassigned issues                                                                                                  
+  --sort               <sort>       - Sort order (can also be set via LINEAR_ISSUE_SORT)                    (Values: "manual", "priority")                         
+  --team               <team>       - Team to list issues for (if not your default team)                                                                           
+  --project            <project>    - Filter by project name                                                                                                       
+  --cycle              <cycle>      - Filter by cycle name, number, or 'active'                                                                                    
+  --milestone          <milestone>  - Filter by project milestone name (requires --project)                                                                        
+  --limit              <limit>      - Maximum number of issues to fetch (default: 50, use 0 for unlimited)  (Default: 50)                                          
+  -w, --web                         - Open in web browser                                                                                                          
+  -a, --app                         - Open in Linear.app                                                                                                           
+  --no-pager                        - Disable automatic paging for long output
 ```
 
 ### title

--- a/src/commands/issue/issue-list.ts
+++ b/src/commands/issue/issue-list.ts
@@ -11,6 +11,7 @@ import {
 import {
   fetchIssuesForState,
   getCycleIdByNameOrNumber,
+  getMilestoneIdByName,
   getProjectIdByName,
   getProjectOptionsByName,
   getTeamIdByKey,
@@ -86,6 +87,10 @@ export const listCommand = new Command()
     "Filter by cycle name, number, or 'active'",
   )
   .option(
+    "--milestone <milestone:string>",
+    "Filter by project milestone name (requires --project)",
+  )
+  .option(
     "--limit <limit:number>",
     "Maximum number of issues to fetch (default: 50, use 0 for unlimited)",
     {
@@ -109,6 +114,7 @@ export const listCommand = new Command()
         team,
         project,
         cycle,
+        milestone,
         limit,
         pager,
       },
@@ -185,6 +191,20 @@ export const listCommand = new Command()
           cycleId = await getCycleIdByNameOrNumber(cycle, teamId)
         }
 
+        let milestoneId: string | undefined
+        if (milestone != null) {
+          if (projectId == null) {
+            throw new ValidationError(
+              "--milestone requires --project to be set",
+              {
+                suggestion:
+                  "Use --project to specify which project the milestone belongs to.",
+              },
+            )
+          }
+          milestoneId = await getMilestoneIdByName(milestone, projectId)
+        }
+
         const { Spinner } = await import("@std/cli/unstable-spinner")
         const showSpinner = shouldShowSpinner()
         const spinner = showSpinner ? new Spinner() : null
@@ -200,6 +220,7 @@ export const listCommand = new Command()
           projectId,
           sort,
           cycleId,
+          milestoneId,
         )
         spinner?.stop()
         const issues = result.issues?.nodes || []

--- a/src/utils/linear.ts
+++ b/src/utils/linear.ts
@@ -421,6 +421,7 @@ export async function fetchIssuesForState(
   projectId?: string,
   sortParam?: "manual" | "priority",
   cycleId?: string,
+  milestoneId?: string,
 ) {
   const sort = sortParam ??
     getOption("issue_sort") as "manual" | "priority" | undefined
@@ -462,6 +463,10 @@ export async function fetchIssuesForState(
 
   if (cycleId) {
     filter.cycle = { id: { eq: cycleId } }
+  }
+
+  if (milestoneId) {
+    filter.projectMilestone = { id: { eq: milestoneId } }
   }
 
   const query = gql(/* GraphQL */ `

--- a/test/commands/issue/__snapshots__/issue-list.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-list.test.ts.snap
@@ -11,21 +11,22 @@ Description:
 
 Options:
 
-  -h, --help                       - Show this help.                                                                                                              
-  -s, --state          <state>     - Filter by issue state (can be repeated for multiple states)           (Default: [ \\x1b[32m"unstarted"\\x1b[39m ], Values: \\x1b[32m"triage"\\x1b[39m, \\x1b[32m"backlog"\\x1b[39m,
-                                                                                                           \\x1b[32m"unstarted"\\x1b[39m, \\x1b[32m"started"\\x1b[39m, \\x1b[32m"completed"\\x1b[39m, \\x1b[32m"canceled"\\x1b[39m)       
-  --all-states                     - Show issues from all states                                                                                                  
-  --assignee           <assignee>  - Filter by assignee (username)                                                                                                
-  -A, --all-assignees              - Show issues for all assignees                                                                                                
-  -U, --unassigned                 - Show only unassigned issues                                                                                                  
-  --sort               <sort>      - Sort order (can also be set via LINEAR_ISSUE_SORT)                    (Values: \\x1b[32m"manual"\\x1b[39m, \\x1b[32m"priority"\\x1b[39m)                         
-  --team               <team>      - Team to list issues for (if not your default team)                                                                           
-  --project            <project>   - Filter by project name                                                                                                       
-  --cycle              <cycle>     - Filter by cycle name, number, or 'active'                                                                                    
-  --limit              <limit>     - Maximum number of issues to fetch (default: 50, use 0 for unlimited)  (Default: \\x1b[33m50\\x1b[39m)                                          
-  -w, --web                        - Open in web browser                                                                                                          
-  -a, --app                        - Open in Linear.app                                                                                                           
-  --no-pager                       - Disable automatic paging for long output                                                                                     
+  -h, --help                        - Show this help.                                                                                                              
+  -s, --state          <state>      - Filter by issue state (can be repeated for multiple states)           (Default: [ \\x1b[32m"unstarted"\\x1b[39m ], Values: \\x1b[32m"triage"\\x1b[39m, \\x1b[32m"backlog"\\x1b[39m,
+                                                                                                            \\x1b[32m"unstarted"\\x1b[39m, \\x1b[32m"started"\\x1b[39m, \\x1b[32m"completed"\\x1b[39m, \\x1b[32m"canceled"\\x1b[39m)       
+  --all-states                      - Show issues from all states                                                                                                  
+  --assignee           <assignee>   - Filter by assignee (username)                                                                                                
+  -A, --all-assignees               - Show issues for all assignees                                                                                                
+  -U, --unassigned                  - Show only unassigned issues                                                                                                  
+  --sort               <sort>       - Sort order (can also be set via LINEAR_ISSUE_SORT)                    (Values: \\x1b[32m"manual"\\x1b[39m, \\x1b[32m"priority"\\x1b[39m)                         
+  --team               <team>       - Team to list issues for (if not your default team)                                                                           
+  --project            <project>    - Filter by project name                                                                                                       
+  --cycle              <cycle>      - Filter by cycle name, number, or 'active'                                                                                    
+  --milestone          <milestone>  - Filter by project milestone name (requires --project)                                                                        
+  --limit              <limit>      - Maximum number of issues to fetch (default: 50, use 0 for unlimited)  (Default: \\x1b[33m50\\x1b[39m)                                          
+  -w, --web                         - Open in web browser                                                                                                          
+  -a, --app                         - Open in Linear.app                                                                                                           
+  --no-pager                        - Disable automatic paging for long output                                                                                     
 
 \`
 stderr:


### PR DESCRIPTION
## Summary

- Adds `--milestone <name>` flag to `linear issue list` to filter issues by project milestone
- Requires `--project` since milestones belong to projects; clear error message if omitted
- Reuses existing `getMilestoneIdByName` helper and `IssueFilter.projectMilestone` API field

## Usage

```bash
linear issue list --project "My Project" --milestone "Phase 1" --sort manual
```

## Test plan

- [x] `deno check` passes on modified files
- [x] All 61 issue command tests pass
- [x] `--milestone` appears in `linear issue list --help`
- [x] Error: `--milestone` without `--project` gives clear message with suggestion
- [x] Error: nonexistent milestone name gives "Milestone not found"
- [x] Happy path: filters issues correctly by milestone against live API
- [x] Skill docs and README updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)