### PR TITLE
fix: strip stray characters from pasted API key on Windows

### DIFF
--- a/src/commands/auth/auth-login.ts
+++ b/src/commands/auth/auth-login.ts
@@ -34,13 +34,13 @@ export const loginCommand = new Command()
   .option("-k, --key <key:string>", "API key (prompted if not provided)")
   .action(async (options) => {
     try {
-      let apiKey = options.key
+      let apiKey = options.key?.trim()
 
       if (!apiKey) {
-        apiKey = await Secret.prompt({
+        apiKey = (await Secret.prompt({
           message: "Enter your Linear API key",
           hint: "Create one at https://linear.app/settings/account/security",
-        })
+        }))?.trim()
       }
 
       if (!apiKey) {
@@ -49,6 +49,9 @@ export const loginCommand = new Command()
             "Create one at https://linear.app/settings/account/security",
         })
       }
+
+      // Strip stray characters that some terminals (e.g. Windows) inject around pasted text
+      apiKey = apiKey.replace(/^[^a-zA-Z0-9_]+|[^a-zA-Z0-9_]+$/g, "")
 
       // Validate the API key by querying the API
       const client = createGraphQLClient(apiKey)


### PR DESCRIPTION
## Summary

- Fixes `auth login` failing with "Invalid API key" when the key is pasted interactively on Windows
- Cliffy's `Secret.prompt` injects tilde (`~`) characters at the start and end of pasted text on Windows terminals (bracket paste mode side-effect), e.g. `~lin_api_xxx~` instead of `lin_api_xxx`
- Trims whitespace and strips non-key characters (`[^a-zA-Z0-9_]`) from both ends of the input

## Test plan

- [x] `auth login --key <key>` still works (unaffected path)
- [x] `auth login` interactive paste on Windows now succeeds
- [x] Verified via debug logging that `Secret.prompt` returns `~`-wrapped value on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)