### PR TITLE
chore: strip version from generated skill docs

### DIFF
--- a/skills/linear-cli/SKILL.md
+++ b/skills/linear-cli/SKILL.md
@@ -8,8 +8,6 @@ allowed-tools: Bash(linear:*), Bash(curl:*)
 
 A CLI to manage Linear issues from the command line, with git and jj integration.
 
-Generated from linear CLI v1.11.1
-
 ## Prerequisites
 
 The `linear` command must be available on PATH. To check:

--- a/skills/linear-cli/SKILL.template.md
+++ b/skills/linear-cli/SKILL.template.md
@@ -8,8 +8,6 @@ allowed-tools: Bash(linear:*), Bash(curl:*)
 
 A CLI to manage Linear issues from the command line, with git and jj integration.
 
-Generated from linear CLI v{{VERSION}}
-
 ## Prerequisites
 
 The `linear` command must be available on PATH. To check:

--- a/skills/linear-cli/references/api.md
+++ b/skills/linear-cli/references/api.md
@@ -6,7 +6,6 @@
 
 ```
 Usage:   linear api [query]
-Version: 1.11.1            
 
 Description:
 

--- a/skills/linear-cli/references/auth.md
+++ b/skills/linear-cli/references/auth.md
@@ -6,7 +6,6 @@
 
 ```
 Usage:   linear auth
-Version: 1.11.1     
 
 Description:
 
@@ -36,7 +35,6 @@ Commands:
 
 ```
 Usage:   linear auth login
-Version: 1.11.1           
 
 Description:
 
@@ -56,7 +54,6 @@ Options:
 
 ```
 Usage:   linear auth logout [workspace]
-Version: 1.11.1                        
 
 Description:
 
@@ -75,7 +72,6 @@ Options:
 
 ```
 Usage:   linear auth list
-Version: 1.11.1          
 
 Description:
 
@@ -93,7 +89,6 @@ Options:
 
 ```
 Usage:   linear auth default [workspace]
-Version: 1.11.1                         
 
 Description:
 
@@ -111,7 +106,6 @@ Options:
 
 ```
 Usage:   linear auth token
-Version: 1.11.1           
 
 Description:
 
@@ -129,7 +123,6 @@ Options:
 
 ```
 Usage:   linear auth whoami
-Version: 1.11.1            
 
 Description:
 
@@ -147,7 +140,6 @@ Options:
 
 ```
 Usage:   linear auth migrate
-Version: 1.11.1             
 
 Description:
 

--- a/skills/linear-cli/references/commands.md
+++ b/skills/linear-cli/references/commands.md
@@ -1,7 +1,5 @@
 # Linear CLI Command Reference
 
-Generated from linear CLI v1.11.1
-
 ## Commands
 
 - [auth](./auth.md) - Manage Linear authentication

--- a/skills/linear-cli/references/config.md
+++ b/skills/linear-cli/references/config.md
@@ -6,7 +6,6 @@
 
 ```
 Usage:   linear config
-Version: 1.11.1       
 
 Description:
 

--- a/skills/linear-cli/references/cycle.md
+++ b/skills/linear-cli/references/cycle.md
@@ -6,7 +6,6 @@
 
 ```
 Usage:   linear cycle
-Version: 1.11.1      
 
 Description:
 
@@ -31,7 +30,6 @@ Commands:
 
 ```
 Usage:   linear cycle list
-Version: 1.11.1           
 
 Description:
 
@@ -50,7 +48,6 @@ Options:
 
 ```
 Usage:   linear cycle view <cycleRef>
-Version: 1.11.1                      
 
 Description:
 

--- a/skills/linear-cli/references/document.md
+++ b/skills/linear-cli/references/document.md
@@ -6,7 +6,6 @@
 
 ```
 Usage:   linear document
-Version: 1.11.1         
 
 Description:
 
@@ -34,7 +33,6 @@ Commands:
 
 ```
 Usage:   linear document list
-Version: 1.11.1              
 
 Description:
 
@@ -56,7 +54,6 @@ Options:
 
 ```
 Usage:   linear document view <id>
-Version: 1.11.1                   
 
 Description:
 
@@ -77,7 +74,6 @@ Options:
 
 ```
 Usage:   linear document create
-Version: 1.11.1                
 
 Description:
 
@@ -102,7 +98,6 @@ Options:
 
 ```
 Usage:   linear document update <documentId>
-Version: 1.11.1                             
 
 Description:
 
@@ -125,7 +120,6 @@ Options:
 
 ```
 Usage:   linear document delete [documentId]
-Version: 1.11.1                             
 
 Description:
 

--- a/skills/linear-cli/references/initiative-update.md
+++ b/skills/linear-cli/references/initiative-update.md
@@ -6,7 +6,6 @@
 
 ```
 Usage:   linear initiative-update
-Version: 1.11.1                  
 
 Description:
 
@@ -31,7 +30,6 @@ Commands:
 
 ```
 Usage:   linear initiative-update create <initiativeId>
-Version: 1.11.1                                        
 
 Description:
 
@@ -53,7 +51,6 @@ Options:
 
 ```
 Usage:   linear initiative-update list <initiativeId>
-Version: 1.11.1                                      
 
 Description:
 

--- a/skills/linear-cli/references/initiative.md
+++ b/skills/linear-cli/references/initiative.md
@@ -6,7 +6,6 @@
 
 ```
 Usage:   linear initiative
-Version: 1.11.1           
 
 Description:
 
@@ -38,7 +37,6 @@ Commands:
 
 ```
 Usage:   linear initiative list
-Version: 1.11.1                
 
 Description:
 
@@ -63,7 +61,6 @@ Options:
 
 ```
 Usage:   linear initiative view <initiativeId>
-Version: 1.11.1                               
 
 Description:
 
@@ -84,7 +81,6 @@ Options:
 
 ```
 Usage:   linear initiative create
-Version: 1.11.1                  
 
 Description:
 
@@ -110,7 +106,6 @@ Options:
 
 ```
 Usage:   linear initiative archive [initiativeId]
-Version: 1.11.1                                  
 
 Description:
 
@@ -132,7 +127,6 @@ Options:
 
 ```
 Usage:   linear initiative update <initiativeId>
-Version: 1.11.1                                 
 
 Description:
 
@@ -158,7 +152,6 @@ Options:
 
 ```
 Usage:   linear initiative unarchive <initiativeId>
-Version: 1.11.1                                    
 
 Description:
 
@@ -177,7 +170,6 @@ Options:
 
 ```
 Usage:   linear initiative delete [initiativeId]
-Version: 1.11.1                                 
 
 Description:
 
@@ -199,7 +191,6 @@ Options:
 
 ```
 Usage:   linear initiative add-project <initiative> <project>
-Version: 1.11.1                                              
 
 Description:
 
@@ -218,7 +209,6 @@ Options:
 
 ```
 Usage:   linear initiative remove-project <initiative> <project>
-Version: 1.11.1                                                 
 
 Description:
 

--- a/skills/linear-cli/references/issue.md
+++ b/skills/linear-cli/references/issue.md
@@ -6,7 +6,6 @@
 
 ```
 Usage:   linear issue
-Version: 1.11.1      
 
 Description:
 
@@ -44,7 +43,6 @@ Commands:
 
 ```
 Usage:   linear issue id
-Version: 1.11.1         
 
 Description:
 
@@ -62,7 +60,6 @@ Options:
 
 ```
 Usage:   linear issue list
-Version: 1.11.1           
 
 Description:
 
@@ -95,7 +92,6 @@ Options:
 
 ```
 Usage:   linear issue title [issueId]
-Version: 1.11.1                      
 
 Description:
 
@@ -113,7 +109,6 @@ Options:
 
 ```
 Usage:   linear issue start [issueId]
-Version: 1.11.1                      
 
 Description:
 
@@ -135,7 +130,6 @@ Options:
 
 ```
 Usage:   linear issue view [issueId]
-Version: 1.11.1                     
 
 Description:
 
@@ -159,7 +153,6 @@ Options:
 
 ```
 Usage:   linear issue url [issueId]
-Version: 1.11.1                    
 
 Description:
 
@@ -177,7 +170,6 @@ Options:
 
 ```
 Usage:   linear issue describe [issueId]
-Version: 1.11.1                         
 
 Description:
 
@@ -196,7 +188,6 @@ Options:
 
 ```
 Usage:   linear issue commits [issueId]
-Version: 1.11.1                        
 
 Description:
 
@@ -214,7 +205,6 @@ Options:
 
 ```
 Usage:   linear issue pull-request [issueId]
-Version: 1.11.1                             
 
 Description:
 
@@ -237,7 +227,6 @@ Options:
 
 ```
 Usage:   linear issue delete [issueId]
-Version: 1.11.1                       
 
 Description:
 
@@ -259,7 +248,6 @@ Options:
 
 ```
 Usage:   linear issue create
-Version: 1.11.1             
 
 Description:
 
@@ -294,7 +282,6 @@ Options:
 
 ```
 Usage:   linear issue update [issueId]
-Version: 1.11.1                       
 
 Description:
 
@@ -326,7 +313,6 @@ Options:
 
 ```
 Usage:   linear issue comment
-Version: 1.11.1              
 
 Description:
 
@@ -351,7 +337,6 @@ Commands:
 
 ```
 Usage:   linear issue comment add [issueId]
-Version: 1.11.1                            
 
 Description:
 
@@ -371,7 +356,6 @@ Options:
 
 ```
 Usage:   linear issue comment delete <commentId>
-Version: 1.11.1                                 
 
 Description:
 
@@ -387,7 +371,6 @@ Options:
 
 ```
 Usage:   linear issue comment update <commentId>
-Version: 1.11.1                                 
 
 Description:
 
@@ -405,7 +388,6 @@ Options:
 
 ```
 Usage:   linear issue comment list [issueId]
-Version: 1.11.1                             
 
 Description:
 
@@ -424,7 +406,6 @@ Options:
 
 ```
 Usage:   linear issue attach <issueId> <filepath>
-Version: 1.11.1                                  
 
 Description:
 
@@ -444,7 +425,6 @@ Options:
 
 ```
 Usage:   linear issue relation
-Version: 1.11.1               
 
 Description:
 
@@ -468,7 +448,6 @@ Commands:
 
 ```
 Usage:   linear issue relation add <issueId> <relationType> <relatedIssueId>
-Version: 1.11.1                                                             
 
 Description:
 
@@ -491,7 +470,6 @@ Examples:
 
 ```
 Usage:   linear issue relation delete <issueId> <relationType> <relatedIssueId>
-Version: 1.11.1                                                                
 
 Description:
 
@@ -507,7 +485,6 @@ Options:
 
 ```
 Usage:   linear issue relation list [issueId]
-Version: 1.11.1                              
 
 Description:
 

--- a/skills/linear-cli/references/label.md
+++ b/skills/linear-cli/references/label.md
@@ -6,7 +6,6 @@
 
 ```
 Usage:   linear label
-Version: 1.11.1      
 
 Description:
 
@@ -32,7 +31,6 @@ Commands:
 
 ```
 Usage:   linear label list
-Version: 1.11.1           
 
 Description:
 
@@ -53,7 +51,6 @@ Options:
 
 ```
 Usage:   linear label create
-Version: 1.11.1             
 
 Description:
 
@@ -76,7 +73,6 @@ Options:
 
 ```
 Usage:   linear label delete <nameOrId>
-Version: 1.11.1                        
 
 Description:
 

--- a/skills/linear-cli/references/milestone.md
+++ b/skills/linear-cli/references/milestone.md
@@ -6,7 +6,6 @@
 
 ```
 Usage:   linear milestone
-Version: 1.11.1          
 
 Description:
 
@@ -34,7 +33,6 @@ Commands:
 
 ```
 Usage:   linear milestone list --project <projectId>
-Version: 1.11.1                                     
 
 Description:
 
@@ -53,7 +51,6 @@ Options:
 
 ```
 Usage:   linear milestone view <milestoneId>
-Version: 1.11.1                             
 
 Description:
 
@@ -71,7 +68,6 @@ Options:
 
 ```
 Usage:   linear milestone create --project <projectId> --name <name>
-Version: 1.11.1                                                     
 
 Description:
 
@@ -93,7 +89,6 @@ Options:
 
 ```
 Usage:   linear milestone update <id>
-Version: 1.11.1                      
 
 Description:
 
@@ -116,7 +111,6 @@ Options:
 
 ```
 Usage:   linear milestone delete <id>
-Version: 1.11.1                      
 
 Description:
 

--- a/skills/linear-cli/references/project-update.md
+++ b/skills/linear-cli/references/project-update.md
@@ -6,7 +6,6 @@
 
 ```
 Usage:   linear project-update
-Version: 1.11.1               
 
 Description:
 
@@ -31,7 +30,6 @@ Commands:
 
 ```
 Usage:   linear project-update create <projectId>
-Version: 1.11.1                                  
 
 Description:
 
@@ -53,7 +51,6 @@ Options:
 
 ```
 Usage:   linear project-update list <projectId>
-Version: 1.11.1                                
 
 Description:
 

--- a/skills/linear-cli/references/project.md
+++ b/skills/linear-cli/references/project.md
@@ -6,7 +6,6 @@
 
 ```
 Usage:   linear project
-Version: 1.11.1        
 
 Description:
 
@@ -34,7 +33,6 @@ Commands:
 
 ```
 Usage:   linear project list
-Version: 1.11.1             
 
 Description:
 
@@ -58,7 +56,6 @@ Options:
 
 ```
 Usage:   linear project view <projectId>
-Version: 1.11.1                         
 
 Description:
 
@@ -78,7 +75,6 @@ Options:
 
 ```
 Usage:   linear project create
-Version: 1.11.1               
 
 Description:
 
@@ -106,7 +102,6 @@ Options:
 
 ```
 Usage:   linear project update <projectId>
-Version: 1.11.1                           
 
 Description:
 
@@ -131,7 +126,6 @@ Options:
 
 ```
 Usage:   linear project delete <projectId>
-Version: 1.11.1                           
 
 Description:
 

--- a/skills/linear-cli/references/schema.md
+++ b/skills/linear-cli/references/schema.md
@@ -6,7 +6,6 @@
 
 ```
 Usage:   linear schema
-Version: 1.11.1       
 
 Description:
 

--- a/skills/linear-cli/references/team.md
+++ b/skills/linear-cli/references/team.md
@@ -6,7 +6,6 @@
 
 ```
 Usage:   linear team
-Version: 1.11.1     
 
 Description:
 
@@ -35,7 +34,6 @@ Commands:
 
 ```
 Usage:   linear team create
-Version: 1.11.1            
 
 Description:
 
@@ -58,7 +56,6 @@ Options:
 
 ```
 Usage:   linear team delete <teamKey>
-Version: 1.11.1                      
 
 Description:
 
@@ -78,7 +75,6 @@ Options:
 
 ```
 Usage:   linear team list
-Version: 1.11.1          
 
 Description:
 
@@ -98,7 +94,6 @@ Options:
 
 ```
 Usage:   linear team id
-Version: 1.11.1        
 
 Description:
 
@@ -116,7 +111,6 @@ Options:
 
 ```
 Usage:   linear team autolinks
-Version: 1.11.1               
 
 Description:
 
@@ -134,7 +128,6 @@ Options:
 
 ```
 Usage:   linear team members [teamKey]
-Version: 1.11.1                       
 
 Description:
 

--- a/skills/linear-cli/scripts/generate-docs.ts
+++ b/skills/linear-cli/scripts/generate-docs.ts
@@ -49,6 +49,11 @@ function stripAnsi(str: string): string {
   return str.replace(/\x1b\[[0-9;]*m/g, "")
 }
 
+function stripVersion(str: string): string {
+  // Remove "Version: X.Y.Z" lines from help output to avoid churn on version bumps
+  return str.replace(/^Version:.*\n?/gm, "").replace(/\n+$/, "")
+}
+
 function parseCommands(helpText: string): string[] {
   const commands: string[] = []
   const lines = helpText.split("\n")
@@ -84,7 +89,7 @@ async function getCommandHelp(cmdPath: string[]): Promise<string> {
   if (!result.success) {
     return result.stderr || "Command help not available"
   }
-  return stripAnsi(result.stdout)
+  return stripVersion(stripAnsi(result.stdout))
 }
 
 async function discoverCommand(cmdPath: string[]): Promise<CommandInfo> {
@@ -180,14 +185,6 @@ function generateCommandDoc(cmd: CommandInfo): string {
   return lines.join("\n")
 }
 
-async function getLinearVersion(): Promise<string> {
-  const result = await run(["linear", "--version"])
-  if (!result.success) return "unknown"
-  // Parse "1.7.0" from version output
-  const match = stripAnsi(result.stdout).match(/(\d+\.\d+\.\d+)/)
-  return match ? match[1] : "unknown"
-}
-
 async function main() {
   console.log("Generating Linear CLI documentation...")
 
@@ -197,9 +194,7 @@ async function main() {
     console.error("Error: linear CLI not found. Is it installed?")
     Deno.exit(1)
   }
-
-  const version = await getLinearVersion()
-  console.log(`Linear CLI version: ${version}`)
+  console.log(`Linear CLI: ${stripAnsi(versionResult.stdout)}`)
 
   // Auto-discover top-level commands from `linear --help`
   console.log("Discovering commands...")
@@ -246,13 +241,13 @@ async function main() {
   }
 
   // Generate index file
-  const indexContent = generateIndex(commands, version)
+  const indexContent = generateIndex(commands)
   await Deno.writeTextFile(join(REFERENCES_DIR, "commands.md"), indexContent)
   console.log("  Generated: commands.md")
 
   // Generate SKILL.md from template
   console.log("Generating SKILL.md from template...")
-  const skillContent = await generateSkillMd(commands, version)
+  const skillContent = await generateSkillMd(commands)
   await Deno.writeTextFile(SKILL_MD, skillContent)
   console.log("  Generated: SKILL.md")
 
@@ -271,12 +266,10 @@ async function main() {
   console.log(`\nDone! Generated ${commands.length + 2} files.`)
 }
 
-function generateIndex(commands: CommandInfo[], version: string): string {
+function generateIndex(commands: CommandInfo[]): string {
   const lines: string[] = []
 
   lines.push("# Linear CLI Command Reference")
-  lines.push("")
-  lines.push(`Generated from linear CLI v${version}`)
   lines.push("")
   lines.push("## Commands")
   lines.push("")
@@ -328,13 +321,11 @@ function generateReferenceToc(commands: CommandInfo[]): string {
 
 async function generateSkillMd(
   commands: CommandInfo[],
-  version: string,
 ): Promise<string> {
   const template = await Deno.readTextFile(SKILL_TEMPLATE)
   return template
     .replace("{{COMMANDS}}", generateCommandsSection(commands))
     .replace("{{REFERENCE_TOC}}", generateReferenceToc(commands))
-    .replace("{{VERSION}}", version)
 }
 
 main()


### PR DESCRIPTION
## Summary

- Removes version strings from all generated skill documentation to eliminate unnecessary churn in PRs when cutting a release
- Adds a `stripVersion` helper that filters `Version: X.Y.Z` lines from CLI help output
- Removes the `Generated from linear CLI vX.Y.Z` line from the SKILL template and command index

## Test plan

- [x] Ran `deno run --allow-run --allow-read --allow-write skills/linear-cli/scripts/generate-docs.ts` successfully
- [x] Verified no version strings remain in generated docs