### PR TITLE
feat: add --project-label flag to issue list

### DIFF
--- a/skills/linear-cli/references/issue.md
+++ b/skills/linear-cli/references/issue.md
@@ -67,23 +67,24 @@ Description:
 
 Options:
 
-  -h, --help                        - Show this help.                                                                                                              
-  -w, --workspace      <slug>       - Target workspace (uses credentials)                                                                                          
-  -s, --state          <state>      - Filter by issue state (can be repeated for multiple states)           (Default: [ "unstarted" ], Values: "triage", "backlog",
-                                                                                                            "unstarted", "started", "completed", "canceled")       
-  --all-states                      - Show issues from all states                                                                                                  
-  --assignee           <assignee>   - Filter by assignee (username)                                                                                                
-  -A, --all-assignees               - Show issues for all assignees                                                                                                
-  -U, --unassigned                  - Show only unassigned issues                                                                                                  
-  --sort               <sort>       - Sort order (can also be set via LINEAR_ISSUE_SORT)                    (Values: "manual", "priority")                         
-  --team               <team>       - Team to list issues for (if not your default team)                                                                           
-  --project            <project>    - Filter by project name                                                                                                       
-  --cycle              <cycle>      - Filter by cycle name, number, or 'active'                                                                                    
-  --milestone          <milestone>  - Filter by project milestone name (requires --project)                                                                        
-  --limit              <limit>      - Maximum number of issues to fetch (default: 50, use 0 for unlimited)  (Default: 50)                                          
-  -w, --web                         - Open in web browser                                                                                                          
-  -a, --app                         - Open in Linear.app                                                                                                           
-  --no-pager                        - Disable automatic paging for long output
+  -h, --help                           - Show this help.                                                                                                                       
+  -w, --workspace      <slug>          - Target workspace (uses credentials)                                                                                                   
+  -s, --state          <state>         - Filter by issue state (can be repeated for multiple states)                    (Default: [ "unstarted" ], Values: "triage", "backlog",
+                                                                                                                        "unstarted", "started", "completed", "canceled")       
+  --all-states                         - Show issues from all states                                                                                                           
+  --assignee           <assignee>      - Filter by assignee (username)                                                                                                         
+  -A, --all-assignees                  - Show issues for all assignees                                                                                                         
+  -U, --unassigned                     - Show only unassigned issues                                                                                                           
+  --sort               <sort>          - Sort order (can also be set via LINEAR_ISSUE_SORT)                             (Values: "manual", "priority")                         
+  --team               <team>          - Team to list issues for (if not your default team)                                                                                    
+  --project            <project>       - Filter by project name                                                                                                                
+  --project-label      <projectLabel>  - Filter by project label name (shows issues from all projects with this label)                                                         
+  --cycle              <cycle>         - Filter by cycle name, number, or 'active'                                                                                             
+  --milestone          <milestone>     - Filter by project milestone name (requires --project)                                                                                 
+  --limit              <limit>         - Maximum number of issues to fetch (default: 50, use 0 for unlimited)           (Default: 50)                                          
+  -w, --web                            - Open in web browser                                                                                                                   
+  -a, --app                            - Open in Linear.app                                                                                                                    
+  --no-pager                           - Disable automatic paging for long output
 ```
 
 ### title

--- a/src/commands/issue/issue-list.ts
+++ b/src/commands/issue/issue-list.ts
@@ -83,6 +83,10 @@ export const listCommand = new Command()
     "Filter by project name",
   )
   .option(
+    "--project-label <projectLabel:string>",
+    "Filter by project label name (shows issues from all projects with this label)",
+  )
+  .option(
     "--cycle <cycle:string>",
     "Filter by cycle name, number, or 'active'",
   )
@@ -113,6 +117,7 @@ export const listCommand = new Command()
         allStates,
         team,
         project,
+        projectLabel,
         cycle,
         milestone,
         limit,
@@ -163,6 +168,16 @@ export const listCommand = new Command()
           )
         }
 
+        if (project != null && projectLabel != null) {
+          throw new ValidationError(
+            "Cannot use --project and --project-label together",
+            {
+              suggestion:
+                "Use --project to filter by a single project, or --project-label to filter by all projects with a given label.",
+            },
+          )
+        }
+
         let projectId: string | undefined
         if (project != null) {
           projectId = await getProjectIdByName(project)
@@ -193,6 +208,15 @@ export const listCommand = new Command()
 
         let milestoneId: string | undefined
         if (milestone != null) {
+          if (projectLabel != null) {
+            throw new ValidationError(
+              "--milestone cannot be used with --project-label",
+              {
+                suggestion:
+                  "Use --project to specify a single project when filtering by milestone.",
+              },
+            )
+          }
           if (projectId == null) {
             throw new ValidationError(
               "--milestone requires --project to be set",
@@ -221,6 +245,7 @@ export const listCommand = new Command()
           sort,
           cycleId,
           milestoneId,
+          projectLabel,
         )
         spinner?.stop()
         const issues = result.issues?.nodes || []

--- a/src/utils/linear.ts
+++ b/src/utils/linear.ts
@@ -422,6 +422,7 @@ export async function fetchIssuesForState(
   sortParam?: "manual" | "priority",
   cycleId?: string,
   milestoneId?: string,
+  projectLabel?: string,
 ) {
   const sort = sortParam ??
     getOption("issue_sort") as "manual" | "priority" | undefined
@@ -459,6 +460,8 @@ export async function fetchIssuesForState(
 
   if (projectId) {
     filter.project = { id: { eq: projectId } }
+  } else if (projectLabel) {
+    filter.project = { labels: { name: { eqIgnoreCase: projectLabel } } }
   }
 
   if (cycleId) {

--- a/test/commands/issue/__snapshots__/issue-list.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-list.test.ts.snap
@@ -11,22 +11,23 @@ Description:
 
 Options:
 
-  -h, --help                        - Show this help.                                                                                                              
-  -s, --state          <state>      - Filter by issue state (can be repeated for multiple states)           (Default: [ \\x1b[32m"unstarted"\\x1b[39m ], Values: \\x1b[32m"triage"\\x1b[39m, \\x1b[32m"backlog"\\x1b[39m,
-                                                                                                            \\x1b[32m"unstarted"\\x1b[39m, \\x1b[32m"started"\\x1b[39m, \\x1b[32m"completed"\\x1b[39m, \\x1b[32m"canceled"\\x1b[39m)       
-  --all-states                      - Show issues from all states                                                                                                  
-  --assignee           <assignee>   - Filter by assignee (username)                                                                                                
-  -A, --all-assignees               - Show issues for all assignees                                                                                                
-  -U, --unassigned                  - Show only unassigned issues                                                                                                  
-  --sort               <sort>       - Sort order (can also be set via LINEAR_ISSUE_SORT)                    (Values: \\x1b[32m"manual"\\x1b[39m, \\x1b[32m"priority"\\x1b[39m)                         
-  --team               <team>       - Team to list issues for (if not your default team)                                                                           
-  --project            <project>    - Filter by project name                                                                                                       
-  --cycle              <cycle>      - Filter by cycle name, number, or 'active'                                                                                    
-  --milestone          <milestone>  - Filter by project milestone name (requires --project)                                                                        
-  --limit              <limit>      - Maximum number of issues to fetch (default: 50, use 0 for unlimited)  (Default: \\x1b[33m50\\x1b[39m)                                          
-  -w, --web                         - Open in web browser                                                                                                          
-  -a, --app                         - Open in Linear.app                                                                                                           
-  --no-pager                        - Disable automatic paging for long output                                                                                     
+  -h, --help                           - Show this help.                                                                                                                       
+  -s, --state          <state>         - Filter by issue state (can be repeated for multiple states)                    (Default: [ \\x1b[32m"unstarted"\\x1b[39m ], Values: \\x1b[32m"triage"\\x1b[39m, \\x1b[32m"backlog"\\x1b[39m,
+                                                                                                                        \\x1b[32m"unstarted"\\x1b[39m, \\x1b[32m"started"\\x1b[39m, \\x1b[32m"completed"\\x1b[39m, \\x1b[32m"canceled"\\x1b[39m)       
+  --all-states                         - Show issues from all states                                                                                                           
+  --assignee           <assignee>      - Filter by assignee (username)                                                                                                         
+  -A, --all-assignees                  - Show issues for all assignees                                                                                                         
+  -U, --unassigned                     - Show only unassigned issues                                                                                                           
+  --sort               <sort>          - Sort order (can also be set via LINEAR_ISSUE_SORT)                             (Values: \\x1b[32m"manual"\\x1b[39m, \\x1b[32m"priority"\\x1b[39m)                         
+  --team               <team>          - Team to list issues for (if not your default team)                                                                                    
+  --project            <project>       - Filter by project name                                                                                                                
+  --project-label      <projectLabel>  - Filter by project label name (shows issues from all projects with this label)                                                         
+  --cycle              <cycle>         - Filter by cycle name, number, or 'active'                                                                                             
+  --milestone          <milestone>     - Filter by project milestone name (requires --project)                                                                                 
+  --limit              <limit>         - Maximum number of issues to fetch (default: 50, use 0 for unlimited)           (Default: \\x1b[33m50\\x1b[39m)                                          
+  -w, --web                            - Open in web browser                                                                                                                   
+  -a, --app                            - Open in Linear.app                                                                                                                    
+  --no-pager                           - Disable automatic paging for long output                                                                                              
 
 \`
 stderr:


### PR DESCRIPTION
## Summary

- Adds `--project-label` flag to `linear issue list` that filters issues from all projects matching a given project label name
- Uses Linear's native GraphQL `project.labels` filter (`eqIgnoreCase`) so no extra API calls are needed
- Mutually exclusive with `--project` and `--milestone` flags, with clear error messages

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] Existing tests pass (snapshot updated for help text)
