### PR TITLE
feat: add --label filter to issue list

### DIFF
--- a/skills/linear-cli/references/issue.md
+++ b/skills/linear-cli/references/issue.md
@@ -82,6 +82,7 @@ Options:
   --project-label      <projectLabel>  - Filter by project label name (shows issues from all projects with this label)                                                         
   --cycle              <cycle>         - Filter by cycle name, number, or 'active'                                                                                             
   --milestone          <milestone>     - Filter by project milestone name (requires --project)                                                                                 
+  -l, --label          <label>         - Filter by label name (can be repeated for multiple labels)                                                                            
   --limit              <limit>         - Maximum number of issues to fetch (default: 50, use 0 for unlimited)           (Default: 50)                                          
   -w, --web                            - Open in web browser                                                                                                                   
   -a, --app                            - Open in Linear.app                                                                                                                    

--- a/src/commands/issue/issue-list.ts
+++ b/src/commands/issue/issue-list.ts
@@ -95,6 +95,11 @@ export const listCommand = new Command()
     "Filter by project milestone name (requires --project)",
   )
   .option(
+    "-l, --label <label:string>",
+    "Filter by label name (can be repeated for multiple labels)",
+    { collect: true },
+  )
+  .option(
     "--limit <limit:number>",
     "Maximum number of issues to fetch (default: 50, use 0 for unlimited)",
     {
@@ -120,6 +125,7 @@ export const listCommand = new Command()
         projectLabel,
         cycle,
         milestone,
+        label: labels,
         limit,
         pager,
       },
@@ -229,6 +235,10 @@ export const listCommand = new Command()
           milestoneId = await getMilestoneIdByName(milestone, projectId)
         }
 
+        const labelNames = labels && labels.length > 0
+          ? labels.flat()
+          : undefined
+
         const { Spinner } = await import("@std/cli/unstable-spinner")
         const showSpinner = shouldShowSpinner()
         const spinner = showSpinner ? new Spinner() : null
@@ -246,6 +256,7 @@ export const listCommand = new Command()
           cycleId,
           milestoneId,
           projectLabel,
+          labelNames,
         )
         spinner?.stop()
         const issues = result.issues?.nodes || []

--- a/src/utils/linear.ts
+++ b/src/utils/linear.ts
@@ -423,6 +423,7 @@ export async function fetchIssuesForState(
   cycleId?: string,
   milestoneId?: string,
   projectLabel?: string,
+  labelNames?: string[],
 ) {
   const sort = sortParam ??
     getOption("issue_sort") as "manual" | "priority" | undefined
@@ -470,6 +471,18 @@ export async function fetchIssuesForState(
 
   if (milestoneId) {
     filter.projectMilestone = { id: { eq: milestoneId } }
+  }
+
+  if (labelNames && labelNames.length > 0) {
+    if (labelNames.length === 1) {
+      filter.labels = { some: { name: { eqIgnoreCase: labelNames[0] } } }
+    } else {
+      filter.labels = {
+        and: labelNames.map((name) => ({
+          some: { name: { eqIgnoreCase: name } },
+        })),
+      }
+    }
   }
 
   const query = gql(/* GraphQL */ `

--- a/test/commands/issue/__snapshots__/issue-link.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-link.test.ts.snap
@@ -25,22 +25,6 @@ stderr:
 ""
 `;
 
-snapshot[`Issue Link Command - link URL to issue 1`] = `
-stdout:
-"✓ Linked to ENG-123: org/repo#42
-"
-stderr:
-""
-`;
-
-snapshot[`Issue Link Command - link URL with custom title 1`] = `
-stdout:
-"✓ Linked to ENG-456: Design document
-"
-stderr:
-""
-`;
-
 snapshot[`Issue Link Command - invalid URL shows error 1`] = `
 stdout:
 ""

--- a/test/commands/issue/__snapshots__/issue-link.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-link.test.ts.snap
@@ -25,6 +25,22 @@ stderr:
 ""
 `;
 
+snapshot[`Issue Link Command - link URL to issue 1`] = `
+stdout:
+"✓ Linked to ENG-123: org/repo#42
+"
+stderr:
+""
+`;
+
+snapshot[`Issue Link Command - link URL with custom title 1`] = `
+stdout:
+"✓ Linked to ENG-456: Design document
+"
+stderr:
+""
+`;
+
 snapshot[`Issue Link Command - invalid URL shows error 1`] = `
 stdout:
 ""

--- a/test/commands/issue/__snapshots__/issue-list.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-list.test.ts.snap
@@ -24,12 +24,22 @@ Options:
   --project-label      <projectLabel>  - Filter by project label name (shows issues from all projects with this label)                                                         
   --cycle              <cycle>         - Filter by cycle name, number, or 'active'                                                                                             
   --milestone          <milestone>     - Filter by project milestone name (requires --project)                                                                                 
+  -l, --label          <label>         - Filter by label name (can be repeated for multiple labels)                                                                            
   --limit              <limit>         - Maximum number of issues to fetch (default: 50, use 0 for unlimited)           (Default: \\x1b[33m50\\x1b[39m)                                          
   -w, --web                            - Open in web browser                                                                                                                   
   -a, --app                            - Open in Linear.app                                                                                                                    
   --no-pager                           - Disable automatic paging for long output                                                                                              
 
 \`
+stderr:
+""
+`;
+
+snapshot[`Issue List Command - Filter By Label 1`] = `
+stdout:
+"◌   ID      TITLE         LABELS E STATE       UPDATED    
+⚠⚠⚠ ENG-101 Fix login bug Bug    3 In Progress 17 days ago
+"
 stderr:
 ""
 `;

--- a/test/commands/issue/issue-list.test.ts
+++ b/test/commands/issue/issue-list.test.ts
@@ -1,6 +1,9 @@
 import { snapshotTest } from "@cliffy/testing"
 import { listCommand } from "../../../src/commands/issue/issue-list.ts"
-import { commonDenoArgs } from "../../utils/test-helpers.ts"
+import {
+  commonDenoArgs,
+  setupMockLinearServer,
+} from "../../utils/test-helpers.ts"
 
 // Test help output
 await snapshotTest({
@@ -11,5 +14,67 @@ await snapshotTest({
   denoArgs: commonDenoArgs,
   async fn() {
     await listCommand.parse()
+  },
+})
+
+await snapshotTest({
+  name: "Issue List Command - Filter By Label",
+  meta: import.meta,
+  colors: false,
+  args: ["--label", "Bug", "--team", "ENG", "--sort", "priority"],
+  denoArgs: commonDenoArgs,
+  async fn() {
+    const { cleanup } = await setupMockLinearServer([
+      {
+        queryName: "GetTeamIdByKey",
+        variables: { team: "ENG" },
+        response: {
+          data: {
+            teams: {
+              nodes: [{ id: "team-eng-id" }],
+            },
+          },
+        },
+      },
+      {
+        queryName: "GetIssuesForState",
+        response: {
+          data: {
+            issues: {
+              nodes: [
+                {
+                  id: "issue-1",
+                  identifier: "ENG-101",
+                  title: "Fix login bug",
+                  priority: 1,
+                  estimate: 3,
+                  assignee: { initials: "MC" },
+                  state: {
+                    id: "state-1",
+                    name: "In Progress",
+                    color: "#f2c94c",
+                  },
+                  labels: {
+                    nodes: [{
+                      id: "label-1",
+                      name: "Bug",
+                      color: "#eb5757",
+                    }],
+                  },
+                  updatedAt: "2026-03-13T10:00:00.000Z",
+                },
+              ],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        },
+      },
+    ], { LINEAR_TEAM_ID: "ENG", LINEAR_ISSUE_SORT: "priority" })
+
+    try {
+      await listCommand.parse()
+    } finally {
+      await cleanup()
+    }
   },
 })


### PR DESCRIPTION
## Summary

Adds `-l, --label <label>` flag to `issue list` for filtering issues by label name. The flag is repeatable — when multiple labels are specified, only issues matching **all** labels are returned.

- Uses `eqIgnoreCase` for case-insensitive label name matching
- Single label: `filter.labels = { some: { name: { eqIgnoreCase: "Bug" } } }`
- Multiple labels: `filter.labels = { and: [{ some: { name: { eqIgnoreCase: "Bug" } } }, ...] }`

### Usage

```bash
# Single label
linear issue list --label Bug

# Multiple labels (AND logic)
linear issue list --label Bug --label "High Priority"

# Combined with other filters
linear issue list --label Bug --state started --cycle active
```

## Test plan

- [x] Added snapshot test for `issue list --label Bug` with mock server
- [x] Updated help text snapshot with new `--label` flag
- [x] `deno fmt` clean
- [x] `deno lint` clean
- [x] All tests pass, existing tests unaffected