### PR TITLE
feat: display issue state in issue view command

### DIFF
--- a/src/commands/issue/issue-view.ts
+++ b/src/commands/issue/issue-view.ts
@@ -122,8 +122,11 @@ export const viewCommand = new Command()
 
       const { identifier } = issueData
 
-      // Build metadata line with project and milestone
+      // Build metadata line with state, project and milestone
       const metaParts: string[] = []
+      if (issueData.state) {
+        metaParts.push(`**State:** ${issueData.state.name}`)
+      }
       if (issueData.project) {
         metaParts.push(`**Project:** ${issueData.project.name}`)
       }

--- a/test/commands/issue/__snapshots__/issue-view.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-view.test.ts.snap
@@ -28,6 +28,8 @@ snapshot[`Issue View Command - With Mock Server Terminal No Comments 1`] = `
 stdout:
 "# TEST-123: Fix authentication bug in login flow
 
+**State:** In Progress
+
 Users are experiencing issues logging in when their session expires. This affects the main authentication flow and needs to be resolved quickly.
 
 ## Steps to reproduce
@@ -50,6 +52,8 @@ snapshot[`Issue View Command - With No Comments Flag 1`] = `
 stdout:
 "# TEST-123: Fix authentication bug in login flow
 
+**State:** In Progress
+
 Users are experiencing issues logging in when their session expires.
 "
 stderr:
@@ -59,6 +63,8 @@ stderr:
 snapshot[`Issue View Command - With Comments Default 1`] = `
 stdout:
 "# TEST-123: Fix authentication bug in login flow
+
+**State:** In Progress
 
 Users are experiencing issues logging in when their session expires.
 
@@ -168,6 +174,8 @@ snapshot[`Issue View Command - With Parent And Sub-issues 1`] = `
 stdout:
 "# TEST-456: Implement user authentication
 
+**State:** In Progress
+
 Add user authentication to the application.
 
 ## Parent
@@ -190,7 +198,7 @@ snapshot[`Issue View Command - With Project And Milestone 1`] = `
 stdout:
 "# TEST-789: Add monitoring dashboards
 
-**Project:** Platform Infrastructure Q1 | **Milestone:** Phase 2: Observability
+**State:** In Progress | **Project:** Platform Infrastructure Q1 | **Milestone:** Phase 2: Observability
 
 Set up Datadog dashboards for the new service.
 "
@@ -202,7 +210,7 @@ snapshot[`Issue View Command - With Cycle 1`] = `
 stdout:
 "# TEST-890: Implement rate limiting
 
-**Project:** API Gateway v2 | **Cycle:** Sprint 7
+**State:** Todo | **Project:** API Gateway v2 | **Cycle:** Sprint 7
 
 Add rate limiting to the API gateway.
 "


### PR DESCRIPTION
## Summary
- Display issue state (e.g., Todo, In Progress, Done) in the metadata line of `linear issue view`
- State is shown before Project/Milestone/Cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

`linear issue view -j` already includes the state, but the regular `linear issue view` doesn't show it. Small QoL improvement.