### PR TITLE
feat: show issue state in view command

### DIFF
--- a/src/commands/issue/issue-view.ts
+++ b/src/commands/issue/issue-view.ts
@@ -5,7 +5,7 @@ import { fetchIssueDetails, getIssueIdentifier } from "../../utils/linear.ts"
 import { openIssuePage } from "../../utils/actions.ts"
 import { formatRelativeTime } from "../../utils/display.ts"
 import { pipeToUserPager, shouldUsePager } from "../../utils/pager.ts"
-import { bold, underline } from "@std/fmt/colors"
+import { bold, rgb24, underline } from "@std/fmt/colors"
 import { ensureDir } from "@std/fs"
 import { join } from "@std/path"
 import { encodeHex } from "@std/encoding/hex"
@@ -122,8 +122,15 @@ export const viewCommand = new Command()
 
       const { identifier } = issueData
 
-      // Build metadata line with project and milestone
+      // Build metadata line with state, project and milestone
       const metaParts: string[] = []
+      if (issueData.state) {
+        const coloredState = rgb24(
+          issueData.state.name,
+          parseInt(issueData.state.color.replace("#", ""), 16),
+        )
+        metaParts.push(`**State:** ${coloredState}`)
+      }
       if (issueData.project) {
         metaParts.push(`**Project:** ${issueData.project.name}`)
       }

--- a/test/commands/issue/__snapshots__/issue-view.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-view.test.ts.snap
@@ -28,6 +28,8 @@ snapshot[`Issue View Command - With Mock Server Terminal No Comments 1`] = `
 stdout:
 "# TEST-123: Fix authentication bug in login flow
 
+**State:** In Progress
+
 Users are experiencing issues logging in when their session expires. This affects the main authentication flow and needs to be resolved quickly.
 
 ## Steps to reproduce
@@ -50,6 +52,8 @@ snapshot[`Issue View Command - With No Comments Flag 1`] = `
 stdout:
 "# TEST-123: Fix authentication bug in login flow
 
+**State:** In Progress
+
 Users are experiencing issues logging in when their session expires.
 "
 stderr:
@@ -59,6 +63,8 @@ stderr:
 snapshot[`Issue View Command - With Comments Default 1`] = `
 stdout:
 "# TEST-123: Fix authentication bug in login flow
+
+**State:** In Progress
 
 Users are experiencing issues logging in when their session expires.
 
@@ -168,6 +174,8 @@ snapshot[`Issue View Command - With Parent And Sub-issues 1`] = `
 stdout:
 "# TEST-456: Implement user authentication
 
+**State:** In Progress
+
 Add user authentication to the application.
 
 ## Parent
@@ -190,7 +198,7 @@ snapshot[`Issue View Command - With Project And Milestone 1`] = `
 stdout:
 "# TEST-789: Add monitoring dashboards
 
-**Project:** Platform Infrastructure Q1 | **Milestone:** Phase 2: Observability
+**State:** In Progress | **Project:** Platform Infrastructure Q1 | **Milestone:** Phase 2: Observability
 
 Set up Datadog dashboards for the new service.
 "
@@ -202,7 +210,7 @@ snapshot[`Issue View Command - With Cycle 1`] = `
 stdout:
 "# TEST-890: Implement rate limiting
 
-**Project:** API Gateway v2 | **Cycle:** Sprint 7
+**State:** Todo | **Project:** API Gateway v2 | **Cycle:** Sprint 7
 
 Add rate limiting to the API gateway.
 "


### PR DESCRIPTION
## Summary
- Adds the issue **state** (e.g., "In Progress", "Done") to the `issue view` plain-text output
- State appears as the first item in the metadata line, colored using the state's configured color via `rgb24`
- The state was already fetched in the GraphQL query and available in `issueData.state` — it just wasn't rendered

## Test plan
- [x] `deno check src/main.ts` passes
- [x] `deno lint` passes
- [x] `deno task test` passes (264 tests, 0 failures)
- [x] Snapshot tests updated to include state in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)