### PR TITLE
feat: show assignee and priority in issue view

### DIFF
--- a/src/commands/issue/issue-view.ts
+++ b/src/commands/issue/issue-view.ts
@@ -122,7 +122,7 @@ export const viewCommand = new Command()
 
       const { identifier } = issueData
 
-      // Build metadata line with state, project and milestone
+      // Build metadata line with state, priority, assignee, project and milestone
       const metaParts: string[] = []
       if (issueData.state) {
         metaParts.push(`**State:** ${issueData.state.name}`)

--- a/src/commands/issue/issue-view.ts
+++ b/src/commands/issue/issue-view.ts
@@ -3,7 +3,7 @@ import { renderMarkdown } from "@littletof/charmd"
 import type { Extension } from "@littletof/charmd"
 import { fetchIssueDetails, getIssueIdentifier } from "../../utils/linear.ts"
 import { openIssuePage } from "../../utils/actions.ts"
-import { formatRelativeTime } from "../../utils/display.ts"
+import { formatRelativeTime, getPriorityDisplay } from "../../utils/display.ts"
 import { pipeToUserPager, shouldUsePager } from "../../utils/pager.ts"
 import { bold, underline } from "@std/fmt/colors"
 import { ensureDir } from "@std/fs"
@@ -127,6 +127,13 @@ export const viewCommand = new Command()
       if (issueData.state) {
         metaParts.push(`**State:** ${issueData.state.name}`)
       }
+      metaParts.push(
+        `**Priority:** ${getPriorityDisplay(issueData.priority)}`,
+      )
+      const assigneeDisplay = issueData.assignee != null
+        ? `@${issueData.assignee.displayName}`
+        : "Unassigned"
+      metaParts.push(`**Assignee:** ${assigneeDisplay}`)
       if (issueData.project) {
         metaParts.push(`**Project:** ${issueData.project.name}`)
       }

--- a/src/utils/linear.ts
+++ b/src/utils/linear.ts
@@ -169,6 +169,8 @@ export async function fetchIssueDetails(
   state: { name: string; color: string }
   project?: { name: string } | null
   projectMilestone?: { name: string } | null
+  assignee?: { name: string; displayName: string } | null
+  priority: number
   cycle?: { name?: string | null; number: number } | null
   parent?: {
     identifier: string
@@ -215,6 +217,11 @@ export async function fetchIssueDetails(
             name
             color
           }
+          assignee {
+            name
+            displayName
+          }
+          priority
           project {
             name
           }
@@ -288,6 +295,11 @@ export async function fetchIssueDetails(
             name
             color
           }
+          assignee {
+            name
+            displayName
+          }
+          priority
           project {
             name
           }

--- a/test/commands/issue/__snapshots__/issue-view.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-view.test.ts.snap
@@ -28,7 +28,7 @@ snapshot[`Issue View Command - With Mock Server Terminal No Comments 1`] = `
 stdout:
 "# TEST-123: Fix authentication bug in login flow
 
-**State:** In Progress
+**State:** In Progress | **Priority:** --- | **Assignee:** Unassigned
 
 Users are experiencing issues logging in when their session expires. This affects the main authentication flow and needs to be resolved quickly.
 
@@ -52,7 +52,7 @@ snapshot[`Issue View Command - With No Comments Flag 1`] = `
 stdout:
 "# TEST-123: Fix authentication bug in login flow
 
-**State:** In Progress
+**State:** In Progress | **Priority:** ▄▆█ | **Assignee:** @Jane Smith
 
 Users are experiencing issues logging in when their session expires.
 "
@@ -64,7 +64,7 @@ snapshot[`Issue View Command - With Comments Default 1`] = `
 stdout:
 "# TEST-123: Fix authentication bug in login flow
 
-**State:** In Progress
+**State:** In Progress | **Priority:** ⚠⚠⚠ | **Assignee:** @John Doe
 
 Users are experiencing issues logging in when their session expires.
 
@@ -112,6 +112,8 @@ stdout:
     "name": "In Progress",
     "color": "#f87462"
   },
+  "assignee": null,
+  "priority": 3,
   "parent": null,
   "children": [],
   "attachments": []
@@ -133,6 +135,11 @@ stdout:
     "name": "In Progress",
     "color": "#f87462"
   },
+  "assignee": {
+    "name": "jane.smith",
+    "displayName": "Jane Smith"
+  },
+  "priority": 2,
   "project": null,
   "projectMilestone": null,
   "parent": null,
@@ -174,7 +181,7 @@ snapshot[`Issue View Command - With Parent And Sub-issues 1`] = `
 stdout:
 "# TEST-456: Implement user authentication
 
-**State:** In Progress
+**State:** In Progress | **Priority:** ▄▆█ | **Assignee:** @Alice Developer
 
 Add user authentication to the application.
 
@@ -198,7 +205,7 @@ snapshot[`Issue View Command - With Project And Milestone 1`] = `
 stdout:
 "# TEST-789: Add monitoring dashboards
 
-**State:** In Progress | **Project:** Platform Infrastructure Q1 | **Milestone:** Phase 2: Observability
+**State:** In Progress | **Priority:** ▄▆  | **Assignee:** @Bob Senior | **Project:** Platform Infrastructure Q1 | **Milestone:** Phase 2: Observability
 
 Set up Datadog dashboards for the new service.
 "
@@ -210,7 +217,7 @@ snapshot[`Issue View Command - With Cycle 1`] = `
 stdout:
 "# TEST-890: Implement rate limiting
 
-**State:** Todo | **Project:** API Gateway v2 | **Cycle:** Sprint 7
+**State:** Todo | **Priority:** ▄   | **Assignee:** Unassigned | **Project:** API Gateway v2 | **Cycle:** Sprint 7
 
 Add rate limiting to the API gateway.
 "

--- a/test/commands/issue/issue-view.test.ts
+++ b/test/commands/issue/issue-view.test.ts
@@ -48,6 +48,8 @@ await snapshotTest({
                 name: "In Progress",
                 color: "#f87462",
               },
+              assignee: null,
+              priority: 0,
               project: null,
               projectMilestone: null,
               parent: null,
@@ -106,6 +108,11 @@ await snapshotTest({
                 name: "In Progress",
                 color: "#f87462",
               },
+              assignee: {
+                name: "jane.smith",
+                displayName: "Jane Smith",
+              },
+              priority: 2,
               project: null,
               projectMilestone: null,
               parent: null,
@@ -161,6 +168,11 @@ await snapshotTest({
                 name: "In Progress",
                 color: "#f87462",
               },
+              assignee: {
+                name: "john.doe",
+                displayName: "John Doe",
+              },
+              priority: 1,
               project: null,
               projectMilestone: null,
               parent: null,
@@ -308,6 +320,8 @@ await snapshotTest({
                 name: "In Progress",
                 color: "#f87462",
               },
+              assignee: null,
+              priority: 3,
               parent: null,
               children: {
                 nodes: [],
@@ -361,6 +375,11 @@ await snapshotTest({
                 name: "In Progress",
                 color: "#f87462",
               },
+              assignee: {
+                name: "jane.smith",
+                displayName: "Jane Smith",
+              },
+              priority: 2,
               project: null,
               projectMilestone: null,
               parent: null,
@@ -445,6 +464,11 @@ await snapshotTest({
                 name: "In Progress",
                 color: "#f87462",
               },
+              assignee: {
+                name: "alice.dev",
+                displayName: "Alice Developer",
+              },
+              priority: 2,
               project: null,
               projectMilestone: null,
               parent: {
@@ -531,6 +555,11 @@ await snapshotTest({
                 name: "In Progress",
                 color: "#f87462",
               },
+              assignee: {
+                name: "bob.senior",
+                displayName: "Bob Senior",
+              },
+              priority: 3,
               project: {
                 name: "Platform Infrastructure Q1",
               },
@@ -589,6 +618,8 @@ await snapshotTest({
                 name: "Todo",
                 color: "#e2e2e2",
               },
+              assignee: null,
+              priority: 4,
               project: {
                 name: "API Gateway v2",
               },


### PR DESCRIPTION
## Summary
- Add **assignee** and **priority** fields to the `issue view` command's metadata line
- Priority uses the existing `getPriorityDisplay` function (same visual format as `issue list`)
- Assignee shows `@displayName` or `Unassigned` when null
- Both GraphQL queries (`GetIssueDetailsWithComments` and `GetIssueDetails`) updated with `assignee { name displayName }` and `priority`

## Motivation
These are critical fields for triaging issues. Previously, `issue view` showed project, milestone, and cycle but not who owns the issue or how urgent it is.

## Example output
```
# ENG-123: Fix authentication bug

**Priority:** ▄▆█ | **Assignee:** @Jane Smith | **Project:** Platform Infrastructure Q1
```

## Test plan
- [x] Updated all 10 issue-view snapshot tests with mock data covering: unassigned/assigned, all priority levels (0-4)
- [x] `deno check src/main.ts` passes
- [x] `deno lint` passes
- [x] All issue-view tests pass (`deno test --allow-all --filter "Issue View"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)