### PR TITLE
feat: add --created-after and --updated-after filters to issue list

### DIFF
--- a/skills/linear-cli/references/issue.md
+++ b/skills/linear-cli/references/issue.md
@@ -84,6 +84,8 @@ Options:
   --milestone          <milestone>     - Filter by project milestone name (requires --project)                                                                                 
   -l, --label          <label>         - Filter by label name (can be repeated for multiple labels)                                                                            
   --limit              <limit>         - Maximum number of issues to fetch (default: 50, use 0 for unlimited)           (Default: 50)                                          
+  --created-after      <date>          - Filter issues created after this date (ISO 8601 or YYYY-MM-DD)                                                                        
+  --updated-after      <date>          - Filter issues updated after this date (ISO 8601 or YYYY-MM-DD)                                                                        
   -w, --web                            - Open in web browser                                                                                                                   
   -a, --app                            - Open in Linear.app                                                                                                                    
   --no-pager                           - Disable automatic paging for long output

--- a/src/commands/issue/issue-list.ts
+++ b/src/commands/issue/issue-list.ts
@@ -106,6 +106,14 @@ export const listCommand = new Command()
       default: 50,
     },
   )
+  .option(
+    "--created-after <date:string>",
+    "Filter issues created after this date (ISO 8601 or YYYY-MM-DD)",
+  )
+  .option(
+    "--updated-after <date:string>",
+    "Filter issues updated after this date (ISO 8601 or YYYY-MM-DD)",
+  )
   .option("-w, --web", "Open in web browser")
   .option("-a, --app", "Open in Linear.app")
   .option("--no-pager", "Disable automatic paging for long output")
@@ -128,6 +136,8 @@ export const listCommand = new Command()
         label: labels,
         limit,
         pager,
+        createdAfter,
+        updatedAfter,
       },
     ) => {
       const usePager = pager !== false
@@ -257,6 +267,8 @@ export const listCommand = new Command()
           milestoneId,
           projectLabel,
           labelNames,
+          createdAfter,
+          updatedAfter,
         )
         spinner?.stop()
         const issues = result.issues?.nodes || []

--- a/src/utils/linear.ts
+++ b/src/utils/linear.ts
@@ -13,6 +13,34 @@ import { getGraphQLClient } from "./graphql.ts"
 import { getCurrentIssueFromVcs } from "./vcs.ts"
 import { NotFoundError, ValidationError } from "./errors.ts"
 
+/**
+ * Validate and parse a date string in ISO 8601 format (YYYY-MM-DD or full ISO 8601).
+ * Rejects permissive date strings that `new Date()` would accept (e.g. "1", "March 2024").
+ */
+export function parseDateFilter(value: string, flagName: string): string {
+  const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}(T[\d:.]+Z?([+-]\d{2}:?\d{2})?)?$/
+  if (!ISO_DATE_RE.test(value)) {
+    throw new ValidationError(
+      `Invalid date format for ${flagName}: "${value}"`,
+      {
+        suggestion:
+          "Use YYYY-MM-DD or ISO 8601 format (e.g. 2024-01-15 or 2024-01-15T09:00:00Z).",
+      },
+    )
+  }
+  const parsed = new Date(value)
+  if (isNaN(parsed.getTime())) {
+    throw new ValidationError(
+      `Invalid date for ${flagName}: "${value}"`,
+      {
+        suggestion:
+          "Use YYYY-MM-DD or ISO 8601 format (e.g. 2024-01-15 or 2024-01-15T09:00:00Z).",
+      },
+    )
+  }
+  return parsed.toISOString()
+}
+
 function isValidLinearIdentifier(id: string): boolean {
   return /^[a-zA-Z0-9]+-[1-9][0-9]*$/i.test(id)
 }
@@ -436,6 +464,8 @@ export async function fetchIssuesForState(
   milestoneId?: string,
   projectLabel?: string,
   labelNames?: string[],
+  createdAfter?: string,
+  updatedAfter?: string,
 ) {
   const sort = sortParam ??
     getOption("issue_sort") as "manual" | "priority" | undefined
@@ -495,6 +525,14 @@ export async function fetchIssuesForState(
         })),
       }
     }
+  }
+
+  if (createdAfter) {
+    filter.createdAt = { gte: parseDateFilter(createdAfter, "--created-after") }
+  }
+
+  if (updatedAfter) {
+    filter.updatedAt = { gte: parseDateFilter(updatedAfter, "--updated-after") }
   }
 
   const query = gql(/* GraphQL */ `

--- a/test/commands/issue/__snapshots__/issue-list.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-list.test.ts.snap
@@ -26,6 +26,8 @@ Options:
   --milestone          <milestone>     - Filter by project milestone name (requires --project)                                                                                 
   -l, --label          <label>         - Filter by label name (can be repeated for multiple labels)                                                                            
   --limit              <limit>         - Maximum number of issues to fetch (default: 50, use 0 for unlimited)           (Default: \\x1b[33m50\\x1b[39m)                                          
+  --created-after      <date>          - Filter issues created after this date (ISO 8601 or YYYY-MM-DD)                                                                        
+  --updated-after      <date>          - Filter issues updated after this date (ISO 8601 or YYYY-MM-DD)                                                                        
   -w, --web                            - Open in web browser                                                                                                                   
   -a, --app                            - Open in Linear.app                                                                                                                    
   --no-pager                           - Disable automatic paging for long output                                                                                              

--- a/test/commands/issue/issue-list.test.ts
+++ b/test/commands/issue/issue-list.test.ts
@@ -1,5 +1,8 @@
 import { snapshotTest } from "@cliffy/testing"
+import { assertThrows } from "@std/assert"
 import { listCommand } from "../../../src/commands/issue/issue-list.ts"
+import { parseDateFilter } from "../../../src/utils/linear.ts"
+import { ValidationError } from "../../../src/utils/errors.ts"
 import {
   commonDenoArgs,
   setupMockLinearServer,
@@ -77,4 +80,56 @@ await snapshotTest({
       await cleanup()
     }
   },
+})
+
+// parseDateFilter unit tests
+
+Deno.test("parseDateFilter - accepts YYYY-MM-DD format", () => {
+  const result = parseDateFilter("2024-01-15", "--created-after")
+  const expected = new Date("2024-01-15").toISOString()
+  if (result !== expected) {
+    throw new Error(`Expected ${expected}, got ${result}`)
+  }
+})
+
+Deno.test("parseDateFilter - accepts full ISO 8601 with time and Z", () => {
+  const result = parseDateFilter("2024-01-15T09:00:00Z", "--created-after")
+  if (result !== "2024-01-15T09:00:00.000Z") {
+    throw new Error(`Expected 2024-01-15T09:00:00.000Z, got ${result}`)
+  }
+})
+
+Deno.test("parseDateFilter - accepts ISO 8601 with timezone offset", () => {
+  const result = parseDateFilter(
+    "2024-01-15T09:00:00+05:30",
+    "--created-after",
+  )
+  const expected = new Date("2024-01-15T09:00:00+05:30").toISOString()
+  if (result !== expected) {
+    throw new Error(`Expected ${expected}, got ${result}`)
+  }
+})
+
+Deno.test('parseDateFilter - rejects permissive date string "1"', () => {
+  assertThrows(
+    () => parseDateFilter("1", "--created-after"),
+    ValidationError,
+    'Invalid date format for --created-after: "1"',
+  )
+})
+
+Deno.test('parseDateFilter - rejects permissive date string "March 2024"', () => {
+  assertThrows(
+    () => parseDateFilter("March 2024", "--updated-after"),
+    ValidationError,
+    'Invalid date format for --updated-after: "March 2024"',
+  )
+})
+
+Deno.test('parseDateFilter - rejects permissive date string "Jan 1"', () => {
+  assertThrows(
+    () => parseDateFilter("Jan 1", "--created-after"),
+    ValidationError,
+    'Invalid date format for --created-after: "Jan 1"',
+  )
 })


### PR DESCRIPTION
## Summary

- Adds `--created-after <date>` and `--updated-after <date>` options to the `issue list` command
- Leverages the Linear GraphQL API's `DateComparator` (`gte` operator) on `IssueFilter.createdAt` and `IssueFilter.updatedAt`
- Invalid date strings are rejected early with a `ValidationError` including a suggestion for the expected format (ISO 8601 / YYYY-MM-DD)

## Test plan

- [x] Snapshot test updated for new help text output
- [x] Unit tests verify `ValidationError` is thrown for invalid `--created-after` values
- [x] Unit tests verify `ValidationError` is thrown for invalid `--updated-after` values
- [x] `deno check src/main.ts` passes
- [x] `deno lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)