### PR TITLE
fix: order issue view comments chronologically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- issue view now orders comment threads chronologically (oldest first), matching Linear's UI
+
 ## [2.0.0] - 2026-04-03
 
 ### Fixed

--- a/src/commands/issue/issue-view.ts
+++ b/src/commands/issue/issue-view.ts
@@ -331,7 +331,7 @@ function deriveCommentView(
     .filter((comment) => comment.parent == null)
     .slice()
     .sort((a, b) =>
-      new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
     )
 
   const commentsById = new Map(comments.map((comment) => [comment.id, comment]))

--- a/test/commands/issue/__snapshots__/issue-view.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-view.test.ts.snap
@@ -71,10 +71,6 @@ Users are experiencing issues logging in when their session expires.
 
 ## Comments
 
-- **@Bob Senior** - *1/15/2024* [thread: comment-4]
-
-  Should we also consider implementing automatic session refresh?
-
 - **@John Doe** - *1/15/2024* [thread: comment-1]
 
   I've reproduced this issue on staging. The session timeout seems to be too aggressive.
@@ -86,6 +82,10 @@ Users are experiencing issues logging in when their session expires.
   - **@Alice Developer** - *1/15/2024*
 
     Sounds good! Also, we should add better error messaging for expired sessions.
+
+- **@Bob Senior** - *1/15/2024* [thread: comment-4]
+
+  Should we also consider implementing automatic session refresh?
 
 
 "
@@ -359,10 +359,6 @@ Check how issue view handles resolved comment threads.
 
 ## Comments
 
-- **@Alice Developer** - *1/15/2024* [thread: comment-root-resolved] [resolved]
-
-  Resolved thread root comment.
-
 - **@John Doe** - *1/15/2024* [thread: comment-root-open]
 
   Open thread root comment.
@@ -370,6 +366,10 @@ Check how issue view handles resolved comment threads.
   - **@Jane Smith** - *1/15/2024*
 
     Reply on the open thread.
+
+- **@Alice Developer** - *1/15/2024* [thread: comment-root-resolved] [resolved]
+
+  Resolved thread root comment.
 
 
 "


### PR DESCRIPTION
## Summary

- `linear issue view` now renders root comment threads oldest-first, matching Linear's UI. Replies within a thread were already chronological.
- The sort is still needed client-side because Linear's `comments(orderBy: createdAt)` connection returns newest-first and the schema (`PaginationOrderBy`) exposes no direction argument.

## Test plan

- [x] `deno task test` (324 passed)
- [x] Updated snapshots for `With Comments Default` and `Show Resolved Threads`