### PR TITLE
feat(project): support overview content on create

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ linear team autolinks  # configure GitHub repository autolinks for Linear issues
 ```bash
 linear project list    # list projects
 linear project view    # view project details
+linear project create --name "API v2" --team ENG --content-file overview.md
+linear project create --name "Mobile launch" --team APP --priority high --label Launch --member jane@example.com
 ```
 
 ### milestone commands

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -238,6 +238,19 @@ linear team autolinks
 
 ### projects
 
+#### create a project
+
+```bash
+# Create with a short description and long-form overview markdown
+linear project create --name "API v2" --team ENG --description "Short summary" --content "## Overview"
+
+# Read the project overview body from a markdown file
+linear project create --name "API v2" --team ENG --content-file overview.md
+
+# Create with priority, labels, members, icon, and color
+linear project create --name "Mobile launch" --team APP --priority high --label Launch --member jane@example.com --icon rocket --color "#5E6AD2"
+```
+
 #### list projects
 
 ```bash

--- a/src/commands/project/project-create.ts
+++ b/src/commands/project/project-create.ts
@@ -1,7 +1,9 @@
 import { Command } from "@cliffy/command"
 import { Input, Select } from "@cliffy/prompt"
 import { gql } from "../../__codegen__/gql.ts"
+import type { ProjectCreateInput } from "../../__codegen__/graphql.ts"
 import { getGraphQLClient } from "../../utils/graphql.ts"
+import type { GraphQLClient } from "graphql-request"
 import {
   getAllTeams,
   getTeamIdByKey,
@@ -50,9 +52,37 @@ const AddProjectToInitiative = gql(`
   }
 `)
 
+const GetProjectLabelIdByName = gql(`
+  query GetProjectLabelIdByNameForCreate($name: String!) {
+    projectLabels(filter: { name: { eqIgnoreCase: $name } }) {
+      nodes {
+        id
+        name
+      }
+    }
+  }
+`)
+
+const PRIORITY_MAPPING: Record<string, number> = {
+  "none": 0,
+  "urgent": 1,
+  "high": 2,
+  "medium": 3,
+  "low": 4,
+}
+
+function parsePriority(priority: string): number {
+  const mapped = PRIORITY_MAPPING[priority.toLowerCase()]
+  if (mapped == null) {
+    throw new ValidationError(`Invalid priority: ${priority}`, {
+      suggestion: "Valid values: none, urgent, high, medium, low",
+    })
+  }
+  return mapped
+}
+
 async function resolveInitiativeId(
-  // deno-lint-ignore no-explicit-any
-  client: any,
+  client: GraphQLClient,
   idOrSlugOrName: string,
 ): Promise<string | undefined> {
   // Try as UUID first
@@ -109,11 +139,49 @@ async function resolveInitiativeId(
   return undefined
 }
 
+export async function resolveProjectContent(
+  content: string | undefined,
+  contentFile: string | undefined,
+): Promise<string | undefined> {
+  if (content != null && contentFile != null) {
+    throw new ValidationError(
+      "Cannot specify both --content and --content-file",
+    )
+  }
+
+  if (contentFile == null) {
+    return content
+  }
+
+  try {
+    return await Deno.readTextFile(contentFile)
+  } catch (error) {
+    throw new ValidationError(`Failed to read content file: ${contentFile}`, {
+      suggestion: `Error: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    })
+  }
+}
+
+async function lookupProjectLabelId(
+  client: GraphQLClient,
+  label: string,
+): Promise<string | undefined> {
+  const result = await client.request(GetProjectLabelIdByName, { name: label })
+  return result.projectLabels?.nodes[0]?.id
+}
+
 export const createCommand = new Command()
   .name("create")
   .description("Create a new Linear project")
   .option("-n, --name <name:string>", "Project name (required)")
   .option("-d, --description <description:string>", "Project description")
+  .option("--content <markdown:string>", "Project overview markdown")
+  .option(
+    "--content-file <path:string>",
+    "Read project overview markdown from a file",
+  )
   .option(
     "-t, --team <team:string>",
     "Team key (required, can be repeated for multiple teams)",
@@ -133,6 +201,22 @@ export const createCommand = new Command()
     "Target completion date (YYYY-MM-DD)",
   )
   .option(
+    "--priority <priority:string>",
+    "Project priority (none, urgent, high, medium, low)",
+  )
+  .option(
+    "--label <label:string>",
+    "Project label associated with the project. May be repeated.",
+    { collect: true },
+  )
+  .option(
+    "--member <user:string>",
+    "Project member (username, email, display name, or @me). May be repeated.",
+    { collect: true },
+  )
+  .option("--icon <icon:string>", "Project icon")
+  .option("--color <color:string>", "Project color as a HEX string")
+  .option(
     "--initiative <initiative:string>",
     "Add to initiative immediately (ID, slug, or name)",
   )
@@ -143,281 +227,332 @@ export const createCommand = new Command()
   .option("-j, --json", "Output created project as JSON")
   .action(
     async (options) => {
-      const {
-        name: providedName,
-        description: providedDescription,
-        team: providedTeams,
-        lead: providedLead,
-        status: providedStatus,
-        startDate: providedStartDate,
-        targetDate: providedTargetDate,
-        initiative: providedInitiative,
-        interactive: interactiveFlag,
-        json: jsonOutput,
-      } = options
-
-      const client = getGraphQLClient()
-      const initiative = providedInitiative
-
-      let name = providedName
-      let description = providedDescription
-      let teams = providedTeams || []
-      let lead = providedLead
-      let status = providedStatus
-      let startDate = providedStartDate
-      let targetDate = providedTargetDate
-
-      // Determine if we should run in interactive mode
-      const noFlagsProvided = !name && teams.length === 0
-      const isInteractive = (noFlagsProvided || interactiveFlag) &&
-        Deno.stdout.isTerminal()
-
-      if (isInteractive) {
-        console.log("\nCreate a new project\n")
-
-        // Name (required)
-        if (!name) {
-          name = await Input.prompt({
-            message: "Project name:",
-            minLength: 1,
-          })
-        }
-
-        // Description (optional)
-        if (!description) {
-          description = await Input.prompt({
-            message: "Description (optional):",
-          })
-          if (!description) description = undefined
-        }
-
-        // Team selection (required)
-        if (teams.length === 0) {
-          const allTeams = await getAllTeams()
-          const teamOptions = allTeams.map((t) => ({
-            name: `${t.name} (${t.key})`,
-            value: t.key,
-          }))
-
-          // Try to get default team from config
-          const defaultTeam = getTeamKey()
-          const defaultIndex = defaultTeam
-            ? teamOptions.findIndex((t) => t.value === defaultTeam)
-            : -1
-
-          const selectedTeam = await Select.prompt({
-            message: "Team:",
-            options: teamOptions,
-            default: defaultIndex >= 0
-              ? teamOptions[defaultIndex].value
-              : undefined,
-          })
-          teams = [selectedTeam]
-        }
-
-        // Status selection - get actual statuses from API
-        if (!status) {
-          const statusResult = await client.request(GetProjectStatuses)
-          const projectStatuses = statusResult.projectStatuses?.nodes || []
-
-          if (projectStatuses.length > 0) {
-            const statusOptions = projectStatuses.map(
-              (s: { id: string; name: string; type: string }) => ({
-                name: s.name,
-                value: s.type,
-              }),
-            )
-
-            // Find default (planned) status
-            const defaultStatus = statusOptions.find(
-              (s: { value: string }) => s.value === "planned",
-            )
-
-            const selectedStatus = await Select.prompt({
-              message: "Status:",
-              options: statusOptions,
-              default: defaultStatus?.value || statusOptions[0]?.value,
-            })
-            status = selectedStatus
-          }
-        }
-
-        // Lead (optional)
-        if (!lead) {
-          lead = await Input.prompt({
-            message: "Lead (username, email, or @me - press Enter to skip):",
-          })
-          if (!lead) lead = undefined
-        }
-
-        // Start date (optional)
-        if (!startDate) {
-          startDate = await Input.prompt({
-            message: "Start date (YYYY-MM-DD - press Enter to skip):",
-          })
-          if (!startDate) startDate = undefined
-        }
-
-        // Target date (optional)
-        if (!targetDate) {
-          targetDate = await Input.prompt({
-            message: "Target date (YYYY-MM-DD - press Enter to skip):",
-          })
-          if (!targetDate) targetDate = undefined
-        }
-      }
-
-      // Validate required fields
-      if (!name) {
-        throw new ValidationError("Project name is required", {
-          suggestion: "Use --name or -n flag to specify a project name.",
-        })
-      }
-
-      if (teams.length === 0) {
-        // Try default team from config
-        const defaultTeam = getTeamKey()
-        if (defaultTeam) {
-          teams = [defaultTeam]
-        } else {
-          throw new ValidationError("At least one team is required", {
-            suggestion: "Use --team or -t flag to specify a team.",
-          })
-        }
-      }
-
-      // Resolve team IDs
-      const teamIds: string[] = []
-      for (const teamKey of teams) {
-        const teamId = await getTeamIdByKey(teamKey.toUpperCase())
-        if (!teamId) {
-          throw new NotFoundError("Team", teamKey)
-        }
-        teamIds.push(teamId)
-      }
-
-      // Build input - resolve all optional fields first
-      let leadId: string | undefined
-      if (lead) {
-        leadId = await lookupUserId(lead)
-        if (!leadId) {
-          throw new NotFoundError("Lead", lead)
-        }
-      }
-
-      let statusId: string | undefined
-      if (status) {
-        // Map display value to API type if needed
-        const statusLower = status.toLowerCase()
-        const statusTypeMapping: Record<string, string> = {
-          "planned": "planned",
-          "in progress": "started",
-          "started": "started",
-          "paused": "paused",
-          "completed": "completed",
-          "canceled": "canceled",
-          "backlog": "backlog",
-        }
-        const apiStatusType = statusTypeMapping[statusLower]
-        if (!apiStatusType) {
-          throw new ValidationError(`Invalid status: ${status}`, {
-            suggestion:
-              "Valid values: planned, started, paused, completed, canceled, backlog",
-          })
-        }
-
-        // Look up the actual status ID from the organization's project statuses
-        const statusResult = await client.request(GetProjectStatuses)
-        const projectStatuses = statusResult.projectStatuses?.nodes || []
-        const matchingStatus = projectStatuses.find(
-          (s: { type: string }) => s.type === apiStatusType,
-        )
-        if (!matchingStatus) {
-          throw new NotFoundError("Project status", apiStatusType)
-        }
-        statusId = matchingStatus.id
-      }
-
-      if (startDate && !/^\d{4}-\d{2}-\d{2}$/.test(startDate)) {
-        throw new ValidationError("Start date must be in YYYY-MM-DD format")
-      }
-
-      if (targetDate && !/^\d{4}-\d{2}-\d{2}$/.test(targetDate)) {
-        throw new ValidationError("Target date must be in YYYY-MM-DD format")
-      }
-
-      const input = {
-        name,
-        teamIds,
-        ...(description && { description }),
-        ...(leadId && { leadId }),
-        ...(statusId && { statusId }),
-        ...(startDate && { startDate }),
-        ...(targetDate && { targetDate }),
-      }
-
-      const { Spinner } = await import("@std/cli/unstable-spinner")
-      const showSpinner = shouldShowSpinner() && !jsonOutput
-      const spinner = showSpinner ? new Spinner() : null
-      spinner?.start()
-
       try {
-        const result = await client.request(CreateProject, { input })
+        const {
+          name: providedName,
+          description: providedDescription,
+          content: providedContent,
+          contentFile: providedContentFile,
+          team: providedTeams,
+          lead: providedLead,
+          status: providedStatus,
+          startDate: providedStartDate,
+          targetDate: providedTargetDate,
+          priority: providedPriority,
+          label: providedLabels,
+          member: providedMembers,
+          icon: providedIcon,
+          color: providedColor,
+          initiative: providedInitiative,
+          interactive: interactiveFlag,
+          json: jsonOutput,
+        } = options
 
-        if (!result.projectCreate.success) {
-          spinner?.stop()
-          throw new CliError("Failed to create project")
-        }
+        const content = await resolveProjectContent(
+          providedContent,
+          providedContentFile,
+        )
+        const priority = providedPriority != null
+          ? parsePriority(providedPriority)
+          : undefined
+        const client = getGraphQLClient()
+        const initiative = providedInitiative
 
-        const project = result.projectCreate.project
-        spinner?.stop()
+        let name = providedName
+        let description = providedDescription
+        let teams = providedTeams || []
+        let lead = providedLead
+        let status = providedStatus
+        let startDate = providedStartDate
+        let targetDate = providedTargetDate
+        const labels = providedLabels || []
+        const members = providedMembers || []
 
-        if (!project) {
-          throw new CliError("Failed to create project: no project returned")
-        }
+        // Determine if we should run in interactive mode
+        const noFlagsProvided = !name && teams.length === 0
+        const isInteractive = (noFlagsProvided || interactiveFlag) &&
+          Deno.stdout.isTerminal()
 
-        // Add to initiative if specified (before JSON output so warnings go to stderr)
-        if (initiative) {
-          const initiativeId = await resolveInitiativeId(client, initiative)
-          if (!initiativeId) {
-            console.error(`\nWarning: Initiative not found: ${initiative}`)
-            console.error("Project was created but not added to initiative.")
-          } else {
-            try {
-              const linkResult = await client.request(AddProjectToInitiative, {
-                input: {
-                  initiativeId,
-                  projectId: project.id,
-                },
-              })
+        if (isInteractive) {
+          console.log("\nCreate a new project\n")
 
-              if (linkResult.initiativeToProjectCreate.success && !jsonOutput) {
-                console.log(`✓ Added to initiative: ${initiative}`)
-              } else if (
-                !linkResult.initiativeToProjectCreate.success
-              ) {
-                console.error(`\nWarning: Failed to add project to initiative`)
-              }
-            } catch (error) {
-              console.error(
-                `\nWarning: Failed to add project to initiative:`,
-                error,
+          // Name (required)
+          if (!name) {
+            name = await Input.prompt({
+              message: "Project name:",
+              minLength: 1,
+            })
+          }
+
+          // Description (optional)
+          if (!description) {
+            description = await Input.prompt({
+              message: "Description (optional):",
+            })
+            if (!description) description = undefined
+          }
+
+          // Team selection (required)
+          if (teams.length === 0) {
+            const allTeams = await getAllTeams()
+            const teamOptions = allTeams.map((t) => ({
+              name: `${t.name} (${t.key})`,
+              value: t.key,
+            }))
+
+            // Try to get default team from config
+            const defaultTeam = getTeamKey()
+            const defaultIndex = defaultTeam
+              ? teamOptions.findIndex((t) => t.value === defaultTeam)
+              : -1
+
+            const selectedTeam = await Select.prompt({
+              message: "Team:",
+              options: teamOptions,
+              default: defaultIndex >= 0
+                ? teamOptions[defaultIndex].value
+                : undefined,
+            })
+            teams = [selectedTeam]
+          }
+
+          // Status selection - get actual statuses from API
+          if (!status) {
+            const statusResult = await client.request(GetProjectStatuses)
+            const projectStatuses = statusResult.projectStatuses?.nodes || []
+
+            if (projectStatuses.length > 0) {
+              const statusOptions = projectStatuses.map(
+                (s: { id: string; name: string; type: string }) => ({
+                  name: s.name,
+                  value: s.type,
+                }),
               )
+
+              // Find default (planned) status
+              const defaultStatus = statusOptions.find(
+                (s: { value: string }) => s.value === "planned",
+              )
+
+              const selectedStatus = await Select.prompt({
+                message: "Status:",
+                options: statusOptions,
+                default: defaultStatus?.value || statusOptions[0]?.value,
+              })
+              status = selectedStatus
             }
           }
-        }
 
-        if (jsonOutput) {
-          console.log(JSON.stringify(result.projectCreate, null, 2))
-        } else {
-          console.log(`✓ Created project: ${project.name}`)
-          console.log(`  Slug: ${project.slugId}`)
-          if (project.url) {
-            console.log(`  URL: ${project.url}`)
+          // Lead (optional)
+          if (!lead) {
+            lead = await Input.prompt({
+              message: "Lead (username, email, or @me - press Enter to skip):",
+            })
+            if (!lead) lead = undefined
+          }
+
+          // Start date (optional)
+          if (!startDate) {
+            startDate = await Input.prompt({
+              message: "Start date (YYYY-MM-DD - press Enter to skip):",
+            })
+            if (!startDate) startDate = undefined
+          }
+
+          // Target date (optional)
+          if (!targetDate) {
+            targetDate = await Input.prompt({
+              message: "Target date (YYYY-MM-DD - press Enter to skip):",
+            })
+            if (!targetDate) targetDate = undefined
           }
         }
+
+        // Validate required fields
+        if (!name) {
+          throw new ValidationError("Project name is required", {
+            suggestion: "Use --name or -n flag to specify a project name.",
+          })
+        }
+
+        if (teams.length === 0) {
+          // Try default team from config
+          const defaultTeam = getTeamKey()
+          if (defaultTeam) {
+            teams = [defaultTeam]
+          } else {
+            throw new ValidationError("At least one team is required", {
+              suggestion: "Use --team or -t flag to specify a team.",
+            })
+          }
+        }
+
+        // Resolve team IDs
+        const teamIds: string[] = []
+        for (const teamKey of teams) {
+          const teamId = await getTeamIdByKey(teamKey.toUpperCase())
+          if (!teamId) {
+            throw new NotFoundError("Team", teamKey)
+          }
+          teamIds.push(teamId)
+        }
+
+        // Build input - resolve all optional fields first
+        let leadId: string | undefined
+        if (lead) {
+          leadId = await lookupUserId(lead)
+          if (!leadId) {
+            throw new NotFoundError("Lead", lead)
+          }
+        }
+
+        let statusId: string | undefined
+        if (status) {
+          // Map display value to API type if needed
+          const statusLower = status.toLowerCase()
+          const statusTypeMapping: Record<string, string> = {
+            "planned": "planned",
+            "in progress": "started",
+            "started": "started",
+            "paused": "paused",
+            "completed": "completed",
+            "canceled": "canceled",
+            "backlog": "backlog",
+          }
+          const apiStatusType = statusTypeMapping[statusLower]
+          if (!apiStatusType) {
+            throw new ValidationError(`Invalid status: ${status}`, {
+              suggestion:
+                "Valid values: planned, started, paused, completed, canceled, backlog",
+            })
+          }
+
+          // Look up the actual status ID from the organization's project statuses
+          const statusResult = await client.request(GetProjectStatuses)
+          const projectStatuses = statusResult.projectStatuses?.nodes || []
+          const matchingStatus = projectStatuses.find(
+            (s: { type: string }) => s.type === apiStatusType,
+          )
+          if (!matchingStatus) {
+            throw new NotFoundError("Project status", apiStatusType)
+          }
+          statusId = matchingStatus.id
+        }
+
+        const labelIds: string[] = []
+        for (const label of labels) {
+          const labelId = await lookupProjectLabelId(client, label)
+          if (!labelId) {
+            throw new NotFoundError("Project label", label)
+          }
+          labelIds.push(labelId)
+        }
+
+        const memberIds: string[] = []
+        for (const member of members) {
+          const memberId = await lookupUserId(member)
+          if (!memberId) {
+            throw new NotFoundError("User", member)
+          }
+          memberIds.push(memberId)
+        }
+
+        if (startDate && !/^\d{4}-\d{2}-\d{2}$/.test(startDate)) {
+          throw new ValidationError("Start date must be in YYYY-MM-DD format")
+        }
+
+        if (targetDate && !/^\d{4}-\d{2}-\d{2}$/.test(targetDate)) {
+          throw new ValidationError("Target date must be in YYYY-MM-DD format")
+        }
+
+        const input: ProjectCreateInput = {
+          name,
+          teamIds,
+          ...(description && { description }),
+          ...(content != null && { content }),
+          ...(leadId && { leadId }),
+          ...(statusId && { statusId }),
+          ...(startDate && { startDate }),
+          ...(targetDate && { targetDate }),
+          ...(priority != null && { priority }),
+          ...(labelIds.length > 0 && { labelIds }),
+          ...(memberIds.length > 0 && { memberIds }),
+          ...(providedIcon != null && { icon: providedIcon }),
+          ...(providedColor != null && { color: providedColor }),
+        }
+
+        const { Spinner } = await import("@std/cli/unstable-spinner")
+        const showSpinner = shouldShowSpinner() && !jsonOutput
+        const spinner = showSpinner ? new Spinner() : null
+        spinner?.start()
+
+        try {
+          const result = await client.request(CreateProject, { input })
+
+          if (!result.projectCreate.success) {
+            spinner?.stop()
+            throw new CliError("Failed to create project")
+          }
+
+          const project = result.projectCreate.project
+          spinner?.stop()
+
+          if (!project) {
+            throw new CliError("Failed to create project: no project returned")
+          }
+
+          // Add to initiative if specified (before JSON output so warnings go to stderr)
+          if (initiative) {
+            const initiativeId = await resolveInitiativeId(client, initiative)
+            if (!initiativeId) {
+              console.error(`\nWarning: Initiative not found: ${initiative}`)
+              console.error("Project was created but not added to initiative.")
+            } else {
+              try {
+                const linkResult = await client.request(
+                  AddProjectToInitiative,
+                  {
+                    input: {
+                      initiativeId,
+                      projectId: project.id,
+                    },
+                  },
+                )
+
+                if (
+                  linkResult.initiativeToProjectCreate.success && !jsonOutput
+                ) {
+                  console.log(`✓ Added to initiative: ${initiative}`)
+                } else if (
+                  !linkResult.initiativeToProjectCreate.success
+                ) {
+                  console.error(
+                    `\nWarning: Failed to add project to initiative`,
+                  )
+                }
+              } catch (error) {
+                console.error(
+                  `\nWarning: Failed to add project to initiative:`,
+                  error,
+                )
+              }
+            }
+          }
+
+          if (jsonOutput) {
+            console.log(JSON.stringify(result.projectCreate, null, 2))
+          } else {
+            console.log(`✓ Created project: ${project.name}`)
+            console.log(`  Slug: ${project.slugId}`)
+            if (project.url) {
+              console.log(`  URL: ${project.url}`)
+            }
+          }
+        } catch (error) {
+          spinner?.stop()
+          handleError(error, "Failed to create project")
+        }
       } catch (error) {
-        spinner?.stop()
         handleError(error, "Failed to create project")
       }
     },

--- a/test/commands/project/__snapshots__/project-create.test.ts.snap
+++ b/test/commands/project/__snapshots__/project-create.test.ts.snap
@@ -11,17 +11,24 @@ Description:
 
 Options:
 
-  -h, --help                        - Show this help.                                                          
-  -n, --name         <name>         - Project name (required)                                                  
-  -d, --description  <description>  - Project description                                                      
-  -t, --team         <team>         - Team key (required, can be repeated for multiple teams)                  
-  -l, --lead         <lead>         - Project lead (username, email, or @me)                                   
-  -s, --status       <status>       - Project status (planned, started, paused, completed, canceled, backlog)  
-  --start-date       <startDate>    - Start date (YYYY-MM-DD)                                                  
-  --target-date      <targetDate>   - Target completion date (YYYY-MM-DD)                                      
-  --initiative       <initiative>   - Add to initiative immediately (ID, slug, or name)                        
-  -i, --interactive                 - Interactive mode (default if no flags provided)                          
-  -j, --json                        - Output created project as JSON                                           
+  -h, --help                        - Show this help.                                                           
+  -n, --name         <name>         - Project name (required)                                                   
+  -d, --description  <description>  - Project description                                                       
+  --content          <markdown>     - Project overview markdown                                                 
+  --content-file     <path>         - Read project overview markdown from a file                                
+  -t, --team         <team>         - Team key (required, can be repeated for multiple teams)                   
+  -l, --lead         <lead>         - Project lead (username, email, or @me)                                    
+  -s, --status       <status>       - Project status (planned, started, paused, completed, canceled, backlog)   
+  --start-date       <startDate>    - Start date (YYYY-MM-DD)                                                   
+  --target-date      <targetDate>   - Target completion date (YYYY-MM-DD)                                       
+  --priority         <priority>     - Project priority (none, urgent, high, medium, low)                        
+  --label            <label>        - Project label associated with the project. May be repeated.               
+  --member           <user>         - Project member (username, email, display name, or @me). May be repeated.  
+  --icon             <icon>         - Project icon                                                              
+  --color            <color>        - Project color as a HEX string                                             
+  --initiative       <initiative>   - Add to initiative immediately (ID, slug, or name)                         
+  -i, --interactive                 - Interactive mode (default if no flags provided)                           
+  -j, --json                        - Output created project as JSON                                            
 
 "
 stderr:
@@ -37,6 +44,38 @@ stdout:
     "slugId": "json-test-project",
     "name": "JSON Test Project",
     "url": "https://linear.app/test/project/json-test-project"
+  }
+}
+'
+stderr:
+""
+`;
+
+snapshot[`Project Create Command - With Content And Create Fields 1`] = `
+stdout:
+'{
+  "success": true,
+  "project": {
+    "id": "550e8400-e29b-41d4-a716-446655440010",
+    "slugId": "detailed-project",
+    "name": "Detailed Project",
+    "url": "https://linear.app/test/project/detailed-project"
+  }
+}
+'
+stderr:
+""
+`;
+
+snapshot[`Project Create Command - With Content File 1`] = `
+stdout:
+'{
+  "success": true,
+  "project": {
+    "id": "550e8400-e29b-41d4-a716-446655440011",
+    "slugId": "file-content-project",
+    "name": "File Content Project",
+    "url": "https://linear.app/test/project/file-content-project"
   }
 }
 '

--- a/test/commands/project/fixtures/project-overview.md
+++ b/test/commands/project/fixtures/project-overview.md
@@ -1,3 +1,0 @@
-# Project Overview
-
-This overview came from a markdown file.

--- a/test/commands/project/fixtures/project-overview.md
+++ b/test/commands/project/fixtures/project-overview.md
@@ -1,0 +1,3 @@
+# Project Overview
+
+This overview came from a markdown file.

--- a/test/commands/project/project-create.test.ts
+++ b/test/commands/project/project-create.test.ts
@@ -261,10 +261,6 @@ await cliffySnapshotTest({
       prefix: "linear-project-overview-",
       suffix: ".md",
     })
-    await Deno.writeTextFile(
-      overviewPath,
-      "# Project Overview\n\nThis overview came from a markdown file.\n",
-    )
 
     const server = new MockLinearServer([
       {
@@ -304,15 +300,21 @@ await cliffySnapshotTest({
       },
     ])
 
-    const contentFileArgIndex = Deno.args.indexOf(
-      "placeholder-replaced-in-test.md",
-    )
-    if (contentFileArgIndex === -1) {
-      throw new Error("Expected content file placeholder argument")
-    }
-    const originalContentFileArg = Deno.args[contentFileArgIndex]
+    let contentFileArgIndex = -1
+    let originalContentFileArg: string | undefined
 
     try {
+      await Deno.writeTextFile(
+        overviewPath,
+        "# Project Overview\n\nThis overview came from a markdown file.\n",
+      )
+      contentFileArgIndex = Deno.args.indexOf(
+        "placeholder-replaced-in-test.md",
+      )
+      if (contentFileArgIndex === -1) {
+        throw new Error("Expected content file placeholder argument")
+      }
+      originalContentFileArg = Deno.args[contentFileArgIndex]
       Deno.args[contentFileArgIndex] = overviewPath
       await server.start()
       Deno.env.set("LINEAR_GRAPHQL_ENDPOINT", server.getEndpoint())
@@ -323,7 +325,9 @@ await cliffySnapshotTest({
       await server.stop()
       Deno.env.delete("LINEAR_GRAPHQL_ENDPOINT")
       Deno.env.delete("LINEAR_API_KEY")
-      Deno.args[contentFileArgIndex] = originalContentFileArg
+      if (contentFileArgIndex !== -1 && originalContentFileArg != null) {
+        Deno.args[contentFileArgIndex] = originalContentFileArg
+      }
       await Deno.remove(overviewPath)
     }
   },

--- a/test/commands/project/project-create.test.ts
+++ b/test/commands/project/project-create.test.ts
@@ -252,11 +252,20 @@ await cliffySnapshotTest({
     "--team",
     "ENG",
     "--content-file",
-    "test/commands/project/fixtures/project-overview.md",
+    "placeholder-replaced-in-test.md",
     "--json",
   ],
   denoArgs: commonDenoArgs,
   async fn() {
+    const overviewPath = await Deno.makeTempFile({
+      prefix: "linear-project-overview-",
+      suffix: ".md",
+    })
+    await Deno.writeTextFile(
+      overviewPath,
+      "# Project Overview\n\nThis overview came from a markdown file.\n",
+    )
+
     const server = new MockLinearServer([
       {
         queryName: "GetTeamIdByKey",
@@ -295,7 +304,16 @@ await cliffySnapshotTest({
       },
     ])
 
+    const contentFileArgIndex = Deno.args.indexOf(
+      "placeholder-replaced-in-test.md",
+    )
+    if (contentFileArgIndex === -1) {
+      throw new Error("Expected content file placeholder argument")
+    }
+    const originalContentFileArg = Deno.args[contentFileArgIndex]
+
     try {
+      Deno.args[contentFileArgIndex] = overviewPath
       await server.start()
       Deno.env.set("LINEAR_GRAPHQL_ENDPOINT", server.getEndpoint())
       Deno.env.set("LINEAR_API_KEY", "Bearer test-token")
@@ -305,6 +323,8 @@ await cliffySnapshotTest({
       await server.stop()
       Deno.env.delete("LINEAR_GRAPHQL_ENDPOINT")
       Deno.env.delete("LINEAR_API_KEY")
+      Deno.args[contentFileArgIndex] = originalContentFileArg
+      await Deno.remove(overviewPath)
     }
   },
 })
@@ -314,7 +334,7 @@ Deno.test("resolveProjectContent rejects mutually exclusive content inputs", asy
     () =>
       resolveProjectContent(
         "Inline overview",
-        "test/commands/project/fixtures/project-overview.md",
+        "overview.md",
       ),
     ValidationError,
     "Cannot specify both --content and --content-file",

--- a/test/commands/project/project-create.test.ts
+++ b/test/commands/project/project-create.test.ts
@@ -1,5 +1,10 @@
 import { snapshotTest as cliffySnapshotTest } from "@cliffy/testing"
-import { createCommand } from "../../../src/commands/project/project-create.ts"
+import { assertRejects } from "@std/assert"
+import {
+  createCommand,
+  resolveProjectContent,
+} from "../../../src/commands/project/project-create.ts"
+import { ValidationError } from "../../../src/utils/errors.ts"
 import { commonDenoArgs } from "../../utils/test-helpers.ts"
 import { MockLinearServer } from "../../utils/mock_linear_server.ts"
 
@@ -71,4 +76,247 @@ await cliffySnapshotTest({
       Deno.env.delete("LINEAR_API_KEY")
     }
   },
+})
+
+// Test project create with overview content and GraphQL-backed fields
+await cliffySnapshotTest({
+  name: "Project Create Command - With Content And Create Fields",
+  meta: import.meta,
+  colors: false,
+  args: [
+    "--name",
+    "Detailed Project",
+    "--team",
+    "ENG",
+    "--description",
+    "Short project description",
+    "--content",
+    "## Overview\nShip the new project experience.",
+    "--lead",
+    "lead@example.com",
+    "--start-date",
+    "2026-06-01",
+    "--target-date",
+    "2026-09-30",
+    "--priority",
+    "high",
+    "--label",
+    "Frontend",
+    "--label",
+    "Backend",
+    "--member",
+    "jane@example.com",
+    "--member",
+    "@me",
+    "--icon",
+    "rocket",
+    "--color",
+    "#5E6AD2",
+    "--json",
+  ],
+  denoArgs: commonDenoArgs,
+  async fn() {
+    const server = new MockLinearServer([
+      {
+        queryName: "GetTeamIdByKey",
+        variables: { team: "ENG" },
+        response: {
+          data: {
+            teams: {
+              nodes: [{ id: "team-eng-123" }],
+            },
+          },
+        },
+      },
+      {
+        queryName: "LookupUser",
+        variables: { input: "lead@example.com" },
+        response: {
+          data: {
+            users: {
+              nodes: [{
+                id: "user-lead-123",
+                email: "lead@example.com",
+                displayName: "Project Lead",
+                name: "lead",
+              }],
+            },
+          },
+        },
+      },
+      {
+        queryName: "GetProjectLabelIdByNameForCreate",
+        variables: { name: "Frontend" },
+        response: {
+          data: {
+            projectLabels: {
+              nodes: [{ id: "project-label-frontend", name: "Frontend" }],
+            },
+          },
+        },
+      },
+      {
+        queryName: "GetProjectLabelIdByNameForCreate",
+        variables: { name: "Backend" },
+        response: {
+          data: {
+            projectLabels: {
+              nodes: [{ id: "project-label-backend", name: "Backend" }],
+            },
+          },
+        },
+      },
+      {
+        queryName: "LookupUser",
+        variables: { input: "jane@example.com" },
+        response: {
+          data: {
+            users: {
+              nodes: [{
+                id: "user-jane-123",
+                email: "jane@example.com",
+                displayName: "Jane Developer",
+                name: "jane",
+              }],
+            },
+          },
+        },
+      },
+      {
+        queryName: "GetViewerId",
+        variables: {},
+        response: {
+          data: {
+            viewer: {
+              id: "user-self-123",
+            },
+          },
+        },
+      },
+      {
+        queryName: "CreateProject",
+        variables: {
+          input: {
+            name: "Detailed Project",
+            teamIds: ["team-eng-123"],
+            description: "Short project description",
+            content: "## Overview\nShip the new project experience.",
+            leadId: "user-lead-123",
+            startDate: "2026-06-01",
+            targetDate: "2026-09-30",
+            priority: 2,
+            labelIds: ["project-label-frontend", "project-label-backend"],
+            memberIds: ["user-jane-123", "user-self-123"],
+            icon: "rocket",
+            color: "#5E6AD2",
+          },
+        },
+        response: {
+          data: {
+            projectCreate: {
+              success: true,
+              project: {
+                id: "550e8400-e29b-41d4-a716-446655440010",
+                slugId: "detailed-project",
+                name: "Detailed Project",
+                url: "https://linear.app/test/project/detailed-project",
+              },
+            },
+          },
+        },
+      },
+    ])
+
+    try {
+      await server.start()
+      Deno.env.set("LINEAR_GRAPHQL_ENDPOINT", server.getEndpoint())
+      Deno.env.set("LINEAR_API_KEY", "Bearer test-token")
+
+      await createCommand.parse()
+    } finally {
+      await server.stop()
+      Deno.env.delete("LINEAR_GRAPHQL_ENDPOINT")
+      Deno.env.delete("LINEAR_API_KEY")
+    }
+  },
+})
+
+// Test project create with content read from a file
+await cliffySnapshotTest({
+  name: "Project Create Command - With Content File",
+  meta: import.meta,
+  colors: false,
+  args: [
+    "--name",
+    "File Content Project",
+    "--team",
+    "ENG",
+    "--content-file",
+    "test/commands/project/fixtures/project-overview.md",
+    "--json",
+  ],
+  denoArgs: commonDenoArgs,
+  async fn() {
+    const server = new MockLinearServer([
+      {
+        queryName: "GetTeamIdByKey",
+        variables: { team: "ENG" },
+        response: {
+          data: {
+            teams: {
+              nodes: [{ id: "team-eng-123" }],
+            },
+          },
+        },
+      },
+      {
+        queryName: "CreateProject",
+        variables: {
+          input: {
+            name: "File Content Project",
+            teamIds: ["team-eng-123"],
+            content:
+              "# Project Overview\n\nThis overview came from a markdown file.\n",
+          },
+        },
+        response: {
+          data: {
+            projectCreate: {
+              success: true,
+              project: {
+                id: "550e8400-e29b-41d4-a716-446655440011",
+                slugId: "file-content-project",
+                name: "File Content Project",
+                url: "https://linear.app/test/project/file-content-project",
+              },
+            },
+          },
+        },
+      },
+    ])
+
+    try {
+      await server.start()
+      Deno.env.set("LINEAR_GRAPHQL_ENDPOINT", server.getEndpoint())
+      Deno.env.set("LINEAR_API_KEY", "Bearer test-token")
+
+      await createCommand.parse()
+    } finally {
+      await server.stop()
+      Deno.env.delete("LINEAR_GRAPHQL_ENDPOINT")
+      Deno.env.delete("LINEAR_API_KEY")
+    }
+  },
+})
+
+Deno.test("resolveProjectContent rejects mutually exclusive content inputs", async () => {
+  await assertRejects(
+    () =>
+      resolveProjectContent(
+        "Inline overview",
+        "test/commands/project/fixtures/project-overview.md",
+      ),
+    ValidationError,
+    "Cannot specify both --content and --content-file",
+  )
 })


### PR DESCRIPTION
## Why

Linear projects have two text fields: a short description and a longer project overview. The CLI only supported the short description, so projects created from the terminal still needed a manual edit in Linear to add goals, plans, specs, or launch notes.

This PR lets users create a project with its overview already filled in, either from inline markdown or a markdown file. That makes `linear project create` more useful for scripted project setup, templates, and project specs kept in a repo.

It also exposes a few existing Linear create fields so users can set priority, labels, members, icon, and color when creating the project instead of doing a follow-up edit.

## What changed

- `linear project create` now accepts `--content` for inline project overview markdown.
- `--content-file` reads the project overview from a markdown file.
- `--content` and `--content-file` are mutually exclusive.
- Project create can now set priority, labels, members, icon, and color.
- The command passes these values through `ProjectCreateInput` using Linear field names.

## Checks

- `deno task codegen`
- `deno task check`
- `deno lint`
- `deno task test`