### PR TITLE
feat(project): add --label flag to project create and update

### DIFF
--- a/skills/linear-cli/references/project.md
+++ b/skills/linear-cli/references/project.md
@@ -92,6 +92,7 @@ Options:
   --start-date       <startDate>    - Start date (YYYY-MM-DD)                                                  
   --target-date      <targetDate>   - Target completion date (YYYY-MM-DD)                                      
   --initiative       <initiative>   - Add to initiative immediately (ID, slug, or name)                        
+  --label            <label>        - Project label associated with the project. May be repeated.              
   -i, --interactive                 - Interactive mode (default if no flags provided)                          
   -j, --json                        - Output created project as JSON
 ```
@@ -117,7 +118,8 @@ Options:
   -l, --lead         <lead>         - Project lead (username, email, or @me)                           
   --start-date       <startDate>    - Start date (YYYY-MM-DD)                                          
   --target-date      <targetDate>   - Target date (YYYY-MM-DD)                                         
-  -t, --team         <team>         - Team key (can be repeated for multiple teams)
+  -t, --team         <team>         - Team key (can be repeated for multiple teams)                    
+  --label            <label>        - Project label associated with the project. May be repeated.
 ```
 
 ### delete

--- a/src/commands/project/project-create.ts
+++ b/src/commands/project/project-create.ts
@@ -1,12 +1,14 @@
 import { Command } from "@cliffy/command"
-import { Input, Select } from "@cliffy/prompt"
+import { Checkbox, Input, Select } from "@cliffy/prompt"
 import { gql } from "../../__codegen__/gql.ts"
 import { getGraphQLClient } from "../../utils/graphql.ts"
 import {
   getAllTeams,
+  getProjectLabels,
   getTeamIdByKey,
   getTeamKey,
   lookupUserId,
+  resolveProjectLabelIds,
 } from "../../utils/linear.ts"
 import { shouldShowSpinner } from "../../utils/hyperlink.ts"
 import {
@@ -49,6 +51,8 @@ const AddProjectToInitiative = gql(`
     }
   }
 `)
+
+const CREATE_PROJECT_LABEL_OPTION = "__create_project_label__"
 
 async function resolveInitiativeId(
   // deno-lint-ignore no-explicit-any
@@ -137,6 +141,11 @@ export const createCommand = new Command()
     "Add to initiative immediately (ID, slug, or name)",
   )
   .option(
+    "--label <label:string>",
+    "Project label associated with the project. May be repeated.",
+    { collect: true },
+  )
+  .option(
     "-i, --interactive",
     "Interactive mode (default if no flags provided)",
   )
@@ -152,6 +161,7 @@ export const createCommand = new Command()
         startDate: providedStartDate,
         targetDate: providedTargetDate,
         initiative: providedInitiative,
+        label: providedLabels,
         interactive: interactiveFlag,
         json: jsonOutput,
       } = options
@@ -166,6 +176,8 @@ export const createCommand = new Command()
       let status = providedStatus
       let startDate = providedStartDate
       let targetDate = providedTargetDate
+      let labels = providedLabels || []
+      let labelIds: string[] = []
 
       // Determine if we should run in interactive mode
       const noFlagsProvided = !name && teams.length === 0
@@ -265,6 +277,40 @@ export const createCommand = new Command()
           })
           if (!targetDate) targetDate = undefined
         }
+
+        if (labels.length === 0) {
+          const projectLabels = await getProjectLabels()
+          const selectedLabelIds = await Checkbox.prompt({
+            message:
+              "Select project labels (use space to select, enter to confirm)",
+            search: projectLabels.length > 0,
+            searchLabel: "Search project labels",
+            options: [
+              ...projectLabels.map((label) => ({
+                name: label.name,
+                value: label.id,
+              })),
+              {
+                name: "Create new project label",
+                value: CREATE_PROJECT_LABEL_OPTION,
+              },
+            ],
+          })
+
+          labelIds = selectedLabelIds.filter((id) =>
+            id !== CREATE_PROJECT_LABEL_OPTION
+          )
+
+          if (selectedLabelIds.includes(CREATE_PROJECT_LABEL_OPTION)) {
+            const newLabels = await Input.prompt({
+              message:
+                "New project label names (comma-separated - press Enter to skip):",
+            })
+            labels = newLabels.split(",").map((label) => label.trim()).filter(
+              Boolean,
+            )
+          }
+        }
       }
 
       // Validate required fields
@@ -346,6 +392,11 @@ export const createCommand = new Command()
         throw new ValidationError("Target date must be in YYYY-MM-DD format")
       }
 
+      if (labels.length > 0) {
+        labelIds.push(...await resolveProjectLabelIds(labels))
+      }
+      labelIds = [...new Set(labelIds)]
+
       const input = {
         name,
         teamIds,
@@ -354,6 +405,7 @@ export const createCommand = new Command()
         ...(statusId && { statusId }),
         ...(startDate && { startDate }),
         ...(targetDate && { targetDate }),
+        ...(labelIds.length > 0 && { labelIds }),
       }
 
       const { Spinner } = await import("@std/cli/unstable-spinner")

--- a/src/commands/project/project-update.ts
+++ b/src/commands/project/project-update.ts
@@ -2,9 +2,11 @@ import { Command } from "@cliffy/command"
 import { gql } from "../../__codegen__/gql.ts"
 import { getGraphQLClient } from "../../utils/graphql.ts"
 import {
+  getProjectLabelIdsForProject,
   getTeamIdByKey,
   lookupUserId,
   resolveProjectId,
+  resolveProjectLabelIds,
 } from "../../utils/linear.ts"
 import { shouldShowSpinner } from "../../utils/hyperlink.ts"
 import {
@@ -70,6 +72,11 @@ export const updateCommand = new Command()
     "Team key (can be repeated for multiple teams)",
     { collect: true },
   )
+  .option(
+    "--label <label:string>",
+    "Project label associated with the project. May be repeated.",
+    { collect: true },
+  )
   .action(
     async (
       {
@@ -80,6 +87,7 @@ export const updateCommand = new Command()
         startDate,
         targetDate,
         team: teams,
+        label: labels,
       },
       projectId,
     ) => {
@@ -90,13 +98,14 @@ export const updateCommand = new Command()
       try {
         if (
           !name && description == null && !status && !lead &&
-          !startDate && !targetDate && (!teams || teams.length === 0)
+          !startDate && !targetDate && (!teams || teams.length === 0) &&
+          (!labels || labels.length === 0)
         ) {
           throw new ValidationError(
             "At least one update option must be provided",
             {
               suggestion:
-                "Use --name, --description, --status, --lead, --start-date, --target-date, or --team",
+                "Use --name, --description, --status, --lead, --start-date, --target-date, --team, or --label",
             },
           )
         }
@@ -162,6 +171,12 @@ export const updateCommand = new Command()
             teamIds.push(teamId)
           }
           input.teamIds = teamIds
+        }
+
+        if (labels && labels.length > 0) {
+          const currentLabelIds = await getProjectLabelIdsForProject(resolvedId)
+          const newLabelIds = await resolveProjectLabelIds(labels)
+          input.labelIds = [...new Set([...currentLabelIds, ...newLabelIds])]
         }
 
         const result = await client.request(UpdateProject, {

--- a/src/utils/linear.ts
+++ b/src/utils/linear.ts
@@ -1,11 +1,14 @@
 import { gql } from "../__codegen__/gql.ts"
 import type {
+  CreateProjectLabelMutation,
   GetAllTeamsQuery,
   GetAllTeamsQueryVariables as _GetAllTeamsQueryVariables,
   GetIssueDetailsQuery,
   GetIssueDetailsWithCommentsQuery,
   GetIssuesForQueryQuery,
   GetIssuesForStateQuery,
+  GetProjectLabelIdsForProjectQuery,
+  GetProjectLabelsQuery,
   GetTeamMembersQuery,
   IssueFilter,
   IssueSortInput,
@@ -14,7 +17,7 @@ import type {
 } from "../__codegen__/graphql.ts"
 import { Select } from "@cliffy/prompt"
 import { getOption } from "../config.ts"
-import { NotFoundError, ValidationError } from "./errors.ts"
+import { CliError, NotFoundError, ValidationError } from "./errors.ts"
 import { getGraphQLClient } from "./graphql.ts"
 import { normalizeIssueIdentifier } from "./issue-identifier.ts"
 import { getCurrentIssueFromVcs } from "./vcs.ts"
@@ -1433,6 +1436,125 @@ export async function getIssueLabelOptionsByNameForTeam(
     a.name.toLowerCase().localeCompare(b.name.toLowerCase())
   )
   return Object.fromEntries(sortedResults.map((t) => [t.id, t.name]))
+}
+
+export type ProjectLabel = { id: string; name: string; color: string }
+
+export async function getProjectLabels(): Promise<ProjectLabel[]> {
+  const client = getGraphQLClient()
+  const query = gql(/* GraphQL */ `
+    query GetProjectLabels($first: Int, $after: String) {
+      projectLabels(
+        first: $first
+        after: $after
+        filter: { isGroup: { eq: false } }
+      ) {
+        nodes {
+          id
+          name
+          color
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  `)
+
+  const allLabels: ProjectLabel[] = []
+  let hasNextPage = true
+  let after: string | null | undefined = undefined
+
+  while (hasNextPage) {
+    const result: GetProjectLabelsQuery = await client.request(query, {
+      first: 100,
+      after,
+    })
+    allLabels.push(...result.projectLabels.nodes)
+    hasNextPage = result.projectLabels.pageInfo.hasNextPage
+    after = result.projectLabels.pageInfo.endCursor
+  }
+
+  return allLabels.sort((a, b) =>
+    a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+  )
+}
+
+export async function resolveProjectLabelIds(
+  labelNames: string[],
+): Promise<string[]> {
+  const client = getGraphQLClient()
+  const createMutation = gql(/* GraphQL */ `
+    mutation CreateProjectLabel($input: ProjectLabelCreateInput!) {
+      projectLabelCreate(input: $input) {
+        success
+        projectLabel {
+          id
+          name
+          color
+        }
+      }
+    }
+  `)
+
+  const labels = await getProjectLabels()
+  const labelIds: string[] = []
+  const seenNames = new Set<string>()
+
+  for (const rawName of labelNames) {
+    const name = rawName.trim()
+    if (!name) continue
+
+    const normalizedName = name.toLowerCase()
+    if (seenNames.has(normalizedName)) continue
+    seenNames.add(normalizedName)
+
+    const existingLabel = labels.find((label) =>
+      label.name.toLowerCase() === normalizedName
+    )
+    if (existingLabel) {
+      labelIds.push(existingLabel.id)
+      continue
+    }
+
+    const result: CreateProjectLabelMutation = await client.request(
+      createMutation,
+      {
+        input: { name, isGroup: false },
+      },
+    )
+    if (!result.projectLabelCreate.success) {
+      throw new CliError(`Failed to create project label: ${name}`)
+    }
+
+    const createdLabel = result.projectLabelCreate.projectLabel
+    labels.push(createdLabel)
+    labelIds.push(createdLabel.id)
+  }
+
+  return labelIds
+}
+
+export async function getProjectLabelIdsForProject(
+  projectId: string,
+): Promise<string[]> {
+  const client = getGraphQLClient()
+  const query = gql(/* GraphQL */ `
+    query GetProjectLabelIdsForProject($id: String!) {
+      project(id: $id) {
+        labelIds
+      }
+    }
+  `)
+
+  const result: GetProjectLabelIdsForProjectQuery = await client.request(
+    query,
+    {
+      id: projectId,
+    },
+  )
+  return [...result.project.labelIds]
 }
 
 export async function getAllTeams(): Promise<

--- a/test/commands/project/__snapshots__/project-create.test.ts.snap
+++ b/test/commands/project/__snapshots__/project-create.test.ts.snap
@@ -20,6 +20,7 @@ Options:
   --start-date       <startDate>    - Start date (YYYY-MM-DD)                                                  
   --target-date      <targetDate>   - Target completion date (YYYY-MM-DD)                                      
   --initiative       <initiative>   - Add to initiative immediately (ID, slug, or name)                        
+  --label            <label>        - Project label associated with the project. May be repeated.              
   -i, --interactive                 - Interactive mode (default if no flags provided)                          
   -j, --json                        - Output created project as JSON                                           
 
@@ -37,6 +38,22 @@ stdout:
     "slugId": "json-test-project",
     "name": "JSON Test Project",
     "url": "https://linear.app/test/project/json-test-project"
+  }
+}
+'
+stderr:
+""
+`;
+
+snapshot[`Project Create Command - With Labels 1`] = `
+stdout:
+'{
+  "success": true,
+  "project": {
+    "id": "550e8400-e29b-41d4-a716-446655440010",
+    "slugId": "project-with-labels",
+    "name": "Project With Labels",
+    "url": "https://linear.app/test/project/project-with-labels"
   }
 }
 '

--- a/test/commands/project/__snapshots__/project-update.test.ts.snap
+++ b/test/commands/project/__snapshots__/project-update.test.ts.snap
@@ -19,6 +19,7 @@ Options:
   --start-date       <startDate>    - Start date (YYYY-MM-DD)                                          
   --target-date      <targetDate>   - Target date (YYYY-MM-DD)                                         
   -t, --team         <team>         - Team key (can be repeated for multiple teams)                    
+  --label            <label>        - Project label associated with the project. May be repeated.      
 
 "
 stderr:
@@ -47,6 +48,15 @@ snapshot[`Project Update Command - Update Status 1`] = `
 stdout:
 "✓ Updated project: Test Project
 https://linear.app/test/project/proj-status
+"
+stderr:
+""
+`;
+
+snapshot[`Project Update Command - Add Labels 1`] = `
+stdout:
+"✓ Updated project: Test Project
+https://linear.app/test/project/proj-labels
 "
 stderr:
 ""

--- a/test/commands/project/project-create.test.ts
+++ b/test/commands/project/project-create.test.ts
@@ -72,3 +72,106 @@ await cliffySnapshotTest({
     }
   },
 })
+
+// Test project create with project labels
+await cliffySnapshotTest({
+  name: "Project Create Command - With Labels",
+  meta: import.meta,
+  colors: false,
+  args: [
+    "--name",
+    "Project With Labels",
+    "--team",
+    "ENG",
+    "--label",
+    "backend",
+    "--label",
+    "frontend",
+    "--json",
+  ],
+  denoArgs: commonDenoArgs,
+  async fn() {
+    const server = new MockLinearServer([
+      {
+        queryName: "GetTeamIdByKey",
+        variables: { team: "ENG" },
+        response: {
+          data: {
+            teams: {
+              nodes: [{ id: "team-eng-123" }],
+            },
+          },
+        },
+      },
+      {
+        queryName: "GetProjectLabels",
+        response: {
+          data: {
+            projectLabels: {
+              nodes: [
+                { id: "label-backend", name: "Backend", color: "#5e6ad2" },
+              ],
+              pageInfo: {
+                hasNextPage: false,
+                endCursor: null,
+              },
+            },
+          },
+        },
+      },
+      {
+        queryName: "CreateProjectLabel",
+        variables: {
+          input: { name: "frontend", isGroup: false },
+        },
+        response: {
+          data: {
+            projectLabelCreate: {
+              success: true,
+              projectLabel: {
+                id: "label-frontend",
+                name: "frontend",
+                color: "#26b5ce",
+              },
+            },
+          },
+        },
+      },
+      {
+        queryName: "CreateProject",
+        variables: {
+          input: {
+            name: "Project With Labels",
+            teamIds: ["team-eng-123"],
+            labelIds: ["label-backend", "label-frontend"],
+          },
+        },
+        response: {
+          data: {
+            projectCreate: {
+              success: true,
+              project: {
+                id: "550e8400-e29b-41d4-a716-446655440010",
+                slugId: "project-with-labels",
+                name: "Project With Labels",
+                url: "https://linear.app/test/project/project-with-labels",
+              },
+            },
+          },
+        },
+      },
+    ])
+
+    try {
+      await server.start()
+      Deno.env.set("LINEAR_GRAPHQL_ENDPOINT", server.getEndpoint())
+      Deno.env.set("LINEAR_API_KEY", "Bearer test-token")
+
+      await createCommand.parse()
+    } finally {
+      await server.stop()
+      Deno.env.delete("LINEAR_GRAPHQL_ENDPOINT")
+      Deno.env.delete("LINEAR_API_KEY")
+    }
+  },
+})

--- a/test/commands/project/project-update.test.ts
+++ b/test/commands/project/project-update.test.ts
@@ -171,3 +171,103 @@ await cliffySnapshotTest({
     }
   },
 })
+
+// Test project update - labels are additive
+await cliffySnapshotTest({
+  name: "Project Update Command - Add Labels",
+  meta: import.meta,
+  colors: false,
+  args: [
+    "550e8400-e29b-41d4-a716-446655440003",
+    "--label",
+    "backend",
+    "--label",
+    "security",
+  ],
+  denoArgs: commonDenoArgs,
+  async fn() {
+    const server = new MockLinearServer([
+      {
+        queryName: "GetProjectLabelIdsForProject",
+        variables: { id: "550e8400-e29b-41d4-a716-446655440003" },
+        response: {
+          data: {
+            project: {
+              labelIds: ["label-existing", "label-backend"],
+            },
+          },
+        },
+      },
+      {
+        queryName: "GetProjectLabels",
+        response: {
+          data: {
+            projectLabels: {
+              nodes: [
+                { id: "label-backend", name: "Backend", color: "#5e6ad2" },
+              ],
+              pageInfo: {
+                hasNextPage: false,
+                endCursor: null,
+              },
+            },
+          },
+        },
+      },
+      {
+        queryName: "CreateProjectLabel",
+        variables: {
+          input: { name: "security", isGroup: false },
+        },
+        response: {
+          data: {
+            projectLabelCreate: {
+              success: true,
+              projectLabel: {
+                id: "label-security",
+                name: "security",
+                color: "#eb5757",
+              },
+            },
+          },
+        },
+      },
+      {
+        queryName: "UpdateProject",
+        variables: {
+          id: "550e8400-e29b-41d4-a716-446655440003",
+          input: {
+            labelIds: ["label-existing", "label-backend", "label-security"],
+          },
+        },
+        response: {
+          data: {
+            projectUpdate: {
+              success: true,
+              project: {
+                id: "550e8400-e29b-41d4-a716-446655440003",
+                slugId: "proj-labels",
+                name: "Test Project",
+                description: null,
+                url: "https://linear.app/test/project/proj-labels",
+                updatedAt: "2024-01-20T15:30:00Z",
+              },
+            },
+          },
+        },
+      },
+    ])
+
+    try {
+      await server.start()
+      Deno.env.set("LINEAR_GRAPHQL_ENDPOINT", server.getEndpoint())
+      Deno.env.set("LINEAR_API_KEY", "Bearer test-token")
+
+      await updateCommand.parse()
+    } finally {
+      await server.stop()
+      Deno.env.delete("LINEAR_GRAPHQL_ENDPOINT")
+      Deno.env.delete("LINEAR_API_KEY")
+    }
+  },
+})


### PR DESCRIPTION
## Summary

- Adds repeatable `--label <label>` to `linear project create` and `linear project update` for Linear ProjectLabel IDs.
- Resolves project labels case-insensitively and creates missing labels via `projectLabelCreate` without forcing a color.
- Keeps `project update --label` additive by preserving current project label IDs and appending new ones.
- Adds interactive project label selection for `project create -i`, including a create-new option.

## Test plan

- [x] `npx --yes deno@2.7.9 task codegen`
- [x] `npx --yes deno@2.7.9 task check`
- [x] `npx --yes deno@2.7.9 lint`
- [x] `TZ=UTC npx --yes deno@2.7.9 task test` (337 passed, 5 ignored)
- [x] `TZ=UTC npx --yes deno@2.7.9 test --allow-all --quiet test/commands/project/project-create.test.ts test/commands/project/project-update.test.ts`