### PR TITLE
fix(upload): default attachments to private, add --public opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,25 @@ linear issue comment update <id>   # update a comment
 linear issue commits               # show all commits for an issue (jj only)
 ```
 
+#### attaching files
+
+attach files to an issue or comment. uploads are **private** by default (readable only by workspace members), matching the Linear web app.
+
+```bash
+linear issue attach ENG-123 ./screenshot.png            # attach a file to an issue
+linear issue attach ENG-123 ./doc.pdf -t "Spec"         # custom attachment title
+linear issue attach ENG-123 ./img.png -c "see this"     # add a linked comment
+linear issue comment add ENG-123 -a ./screenshot.png    # attach a file to a comment
+linear issue comment add ENG-123 -a ./a.png -a ./b.png  # attach multiple files
+```
+
+by default attachments are private. pass `--public` to upload raster images (png/jpeg/gif/webp/bmp/tiff) to a public `public.linear.app` URL readable by **anyone, unauthenticated** — useful for sharing outside the workspace, but a warning is printed since it bypasses workspace access controls. non-image files cannot be made public.
+
+```bash
+linear issue attach ENG-123 ./screenshot.png --public           # public image URL
+linear issue comment add ENG-123 -a ./screenshot.png --public   # public image URL
+```
+
 ### team commands
 
 ```bash

--- a/skills/linear-cli/references/issue.md
+++ b/skills/linear-cli/references/issue.md
@@ -388,12 +388,14 @@ Description:
 
 Options:
 
-  -h, --help                - Show this help.                                                 
-  --workspace   <slug>      - Target workspace (uses credentials)                             
-  -b, --body    <text>      - Comment body text                                               
-  --body-file   <path>      - Read comment body from a file (preferred for markdown content)  
-  -p, --parent  <id>        - Parent comment ID for replies                                   
-  -a, --attach  <filepath>  - Attach a file to the comment (can be used multiple times)
+  -h, --help                - Show this help.                                                             
+  --workspace   <slug>      - Target workspace (uses credentials)                                         
+  -b, --body    <text>      - Comment body text                                                           
+  --body-file   <path>      - Read comment body from a file (preferred for markdown content)              
+  -p, --parent  <id>        - Parent comment ID for replies                                               
+  -a, --attach  <filepath>  - Attach a file to the comment (can be used multiple times)                   
+  --public                  - Upload attached images to a public, unauthenticated URL (default: private,  
+                              workspace-members only)
 ```
 
 ##### delete
@@ -457,10 +459,12 @@ Description:
 
 Options:
 
-  -h, --help              - Show this help.                              
-  --workspace    <slug>   - Target workspace (uses credentials)          
-  -t, --title    <title>  - Custom title for the attachment              
-  -c, --comment  <body>   - Add a comment body linked to the attachment
+  -h, --help              - Show this help.                                                    
+  --workspace    <slug>   - Target workspace (uses credentials)                                
+  -t, --title    <title>  - Custom title for the attachment                                    
+  -c, --comment  <body>   - Add a comment body linked to the attachment                        
+  --public                - Upload images to a public, unauthenticated URL (default: private,  
+                            workspace-members only)
 ```
 
 ### link

--- a/src/commands/issue/issue-attach.ts
+++ b/src/commands/issue/issue-attach.ts
@@ -24,8 +24,12 @@ export const attachCommand = new Command()
     "-c, --comment <body:string>",
     "Add a comment body linked to the attachment",
   )
+  .option(
+    "--public",
+    "Upload images to a public, unauthenticated URL (default: private, workspace-members only)",
+  )
   .action(async (options, issueId, filepath) => {
-    const { title, comment } = options
+    const { title, comment, public: makePublic } = options
 
     try {
       const resolvedIdentifier = await getIssueIdentifier(issueId)
@@ -56,8 +60,14 @@ export const attachCommand = new Command()
       // Upload the file
       const uploadResult = await uploadFile(filepath, {
         showProgress: shouldShowSpinner(),
+        makePublic,
       })
       console.log(`✓ Uploaded ${uploadResult.filename}`)
+      if (uploadResult.public) {
+        console.warn(
+          `⚠ Uploaded to a public URL readable by anyone: ${uploadResult.assetUrl}`,
+        )
+      }
 
       // Create the attachment
       const mutation = gql(`

--- a/src/commands/issue/issue-comment-add.ts
+++ b/src/commands/issue/issue-comment-add.ts
@@ -26,8 +26,12 @@ export const commentAddCommand = new Command()
     "Attach a file to the comment (can be used multiple times)",
     { collect: true },
   )
+  .option(
+    "--public",
+    "Upload attached images to a public, unauthenticated URL (default: private, workspace-members only)",
+  )
   .action(async (options, issueId) => {
-    const { body, bodyFile, parent, attach } = options
+    const { body, bodyFile, parent, attach, public: makePublic } = options
 
     try {
       // Validate that body and bodyFile are not both provided
@@ -80,6 +84,7 @@ export const commentAddCommand = new Command()
         for (const filepath of attachments) {
           const result = await uploadFile(filepath, {
             showProgress: shouldShowSpinner(),
+            makePublic,
           })
           uploadedFiles.push({
             filename: result.filename,
@@ -87,6 +92,11 @@ export const commentAddCommand = new Command()
             isImage: result.contentType.startsWith("image/"),
           })
           console.log(`✓ Uploaded ${result.filename}`)
+          if (result.public) {
+            console.warn(
+              `⚠ Uploaded to a public URL readable by anyone: ${result.assetUrl}`,
+            )
+          }
         }
       }
 
@@ -111,7 +121,6 @@ export const commentAddCommand = new Command()
             contentType: file.isImage
               ? "image/png"
               : "application/octet-stream",
-            size: 0,
           })
         })
 

--- a/src/utils/upload.ts
+++ b/src/utils/upload.ts
@@ -111,13 +111,19 @@ export interface UploadResult {
   size: number
   /** The MIME type of the file */
   contentType: string
+  /** Whether the file was uploaded to a public, unauthenticated URL */
+  public: boolean
 }
 
 /**
  * Options for file upload
  */
 export interface UploadOptions {
-  /** Make the file publicly accessible (only works for images, default: auto-detect) */
+  /**
+   * Upload the file to a public, unauthenticated URL. Only supported for raster
+   * images. Defaults to false (private, workspace-members only) to match the
+   * Linear web app.
+   */
   makePublic?: boolean
   /** Show progress indicator */
   showProgress?: boolean
@@ -137,6 +143,30 @@ function canBePublic(contentType: string): boolean {
     "image/tiff",
   ]
   return publicTypes.includes(contentType)
+}
+
+/**
+ * Resolve the effective `makePublic` value for an upload.
+ *
+ * Uploads default to private (workspace-members only), matching Linear's web
+ * app. Public is opt-in and only valid for raster image types — requesting it
+ * for any other content type is an error rather than a silent downgrade.
+ */
+export function resolveMakePublic(
+  contentType: string,
+  requested?: boolean,
+): boolean {
+  const makePublic = requested ?? false
+  if (makePublic && !canBePublic(contentType)) {
+    throw new ValidationError(
+      `Cannot upload ${contentType || "this file"} to a public URL`,
+      {
+        suggestion:
+          "Linear only allows public uploads for raster images (png, jpeg, gif, webp, bmp, tiff). Remove --public to upload privately.",
+      },
+    )
+  }
+  return makePublic
 }
 
 /**
@@ -177,6 +207,10 @@ export async function uploadFile(
   const filename = basename(filepath)
   const contentType = getMimeType(filepath)
 
+  // Default to private; public is an explicit opt-in and only valid for images.
+  // Validate before doing any network work or starting the spinner.
+  const makePublic = resolveMakePublic(contentType, options.makePublic)
+
   // Step 1: Request signed upload URL
   const mutation = gql(`
     mutation FileUpload($contentType: String!, $filename: String!, $size: Int!, $makePublic: Boolean) {
@@ -201,9 +235,6 @@ export async function uploadFile(
     ? new Spinner({ message: `Uploading ${filename}...` })
     : null
   spinner?.start()
-
-  // Auto-detect makePublic based on file type (only images can be public)
-  const makePublic = options.makePublic ?? canBePublic(contentType)
 
   try {
     const data = await client.request(mutation, {
@@ -252,6 +283,7 @@ export async function uploadFile(
       filename,
       size,
       contentType,
+      public: makePublic,
     }
   } catch (error) {
     spinner?.stop()
@@ -302,7 +334,9 @@ export async function validateFilePath(filepath: string): Promise<void> {
 /**
  * Format an uploaded file as a markdown link
  */
-export function formatAsMarkdownLink(result: UploadResult): string {
+export function formatAsMarkdownLink(
+  result: Pick<UploadResult, "filename" | "assetUrl" | "contentType">,
+): string {
   const isImage = result.contentType.startsWith("image/")
   if (isImage) {
     return `![${result.filename}](${result.assetUrl})`

--- a/test/utils/upload.test.ts
+++ b/test/utils/upload.test.ts
@@ -1,0 +1,47 @@
+import { assertEquals, assertThrows } from "@std/assert"
+import { resolveMakePublic } from "../../src/utils/upload.ts"
+import { ValidationError } from "../../src/utils/errors.ts"
+
+Deno.test("resolveMakePublic - defaults to private when not requested", () => {
+  assertEquals(resolveMakePublic("image/png"), false)
+  assertEquals(resolveMakePublic("image/png", undefined), false)
+})
+
+Deno.test("resolveMakePublic - defaults to private for non-image types", () => {
+  assertEquals(resolveMakePublic("application/pdf"), false)
+})
+
+Deno.test("resolveMakePublic - allows public for raster images when requested", () => {
+  for (
+    const type of [
+      "image/png",
+      "image/jpeg",
+      "image/gif",
+      "image/webp",
+      "image/bmp",
+      "image/tiff",
+    ]
+  ) {
+    assertEquals(resolveMakePublic(type, true), true)
+  }
+})
+
+Deno.test("resolveMakePublic - explicit false stays private even for images", () => {
+  assertEquals(resolveMakePublic("image/png", false), false)
+})
+
+Deno.test("resolveMakePublic - rejects public for non-public-capable types", () => {
+  // SVG is an image but not allowed to be public by Linear
+  assertThrows(
+    () => resolveMakePublic("image/svg+xml", true),
+    ValidationError,
+  )
+  assertThrows(
+    () => resolveMakePublic("application/pdf", true),
+    ValidationError,
+  )
+  assertThrows(
+    () => resolveMakePublic("application/octet-stream", true),
+    ValidationError,
+  )
+})


### PR DESCRIPTION
[🤖 Claude Opus 4.8 - approved by @tjmgregory]

Fixes #233

## Problem

Image attachments uploaded via `linear issue attach` and `linear issue comment add --attach` were sent with `makePublic` auto-detected to `true` for raster images, producing a `https://public.linear.app/…` URL readable by **anyone, unauthenticated**, with no flag/config/env to opt out. This silently published screenshots of internal data from private workspaces — surprising, since attaching in the Linear web app keeps files workspace-private.

## Fix

- **Default to private.** `uploadFile()` now defaults `makePublic` to `false` (→ `uploads.linear.app`, auth-required), matching Linear's web app and Linear's own API default. Public is now opt-in.
- **`--public` flag** added to both `issue attach` and `issue comment add`. It's only valid for raster images (png/jpeg/gif/webp/bmp/tiff); requesting it for any other type is now a `ValidationError` rather than a silent downgrade.
- **Warning on public uploads.** Both commands print `⚠ Uploaded to a public URL readable by anyone: <url>` whenever an upload lands on a public URL.
- **Docs.** Added an "attaching files" section to the README (the attachment commands were previously undocumented) describing the private-by-default behaviour and `--public`. Regenerated the `issue` skill reference.

## Implementation notes

The public-resolution logic is extracted into a pure, exported `resolveMakePublic(contentType, requested)` helper so the default + validation rules are unit-tested directly. Validation now runs before any network work or the spinner starts.

## Tests

- Added `test/utils/upload.test.ts` covering `resolveMakePublic` (private default, image opt-in, explicit `false`, and rejection of public for non-image / SVG types). All pass.
- `deno task check`, `deno fmt`, and `deno lint` are clean on the changed files.
- Note: the repo's pre-existing help-text snapshot tests fail in my local environment regardless of this change (they fail on a clean checkout too — appears terminal/locale-dependent), so I did not regenerate snapshots.

## Behaviour

| upload | before | after |
| --- | --- | --- |
| image via `attach` (no flag) | `public.linear.app` (world-readable) | `uploads.linear.app` (workspace-only) |
| image via `attach --public` | n/a (no flag) | `public.linear.app` + warning |
| non-image via `attach --public` | n/a | error: only raster images can be public |

🤖 Generated with [Claude Code](https://claude.com/claude-code)