### PR TITLE
Follow-up to #234: reject --public per-batch before any upload

### DIFF
--- a/src/commands/issue/issue-comment-add.ts
+++ b/src/commands/issue/issue-comment-add.ts
@@ -5,6 +5,8 @@ import { getGraphQLClient } from "../../utils/graphql.ts"
 import { getIssueIdentifier } from "../../utils/linear.ts"
 import {
   formatAsMarkdownLink,
+  getMimeType,
+  resolveMakePublic,
   uploadFile,
   validateFilePath,
 } from "../../utils/upload.ts"
@@ -68,6 +70,12 @@ export const commentAddCommand = new Command()
 
       // Validate and upload attachments first
       const attachments = attach || []
+      if (makePublic && attachments.length === 0) {
+        throw new ValidationError(
+          "--public requires at least one --attach",
+          { suggestion: "Add --attach <file> to upload, or remove --public." },
+        )
+      }
       const uploadedFiles: {
         filename: string
         assetUrl: string
@@ -75,9 +83,12 @@ export const commentAddCommand = new Command()
       }[] = []
 
       if (attachments.length > 0) {
-        // Validate all files exist before uploading
+        // Validate all files exist and, if --public, that every file may be
+        // uploaded publicly — before uploading any, so a mixed batch cannot
+        // publish some files before failing on an unsupported one.
         for (const filepath of attachments) {
           await validateFilePath(filepath)
+          resolveMakePublic(getMimeType(filepath), makePublic)
         }
 
         // Upload files

--- a/test/commands/issue/issue-comment-add.test.ts
+++ b/test/commands/issue/issue-comment-add.test.ts
@@ -1,4 +1,6 @@
 import { snapshotTest } from "@cliffy/testing"
+import { assertEquals } from "@std/assert"
+import { stub } from "@std/testing/mock"
 import { commentAddCommand } from "../../../src/commands/issue/issue-comment-add.ts"
 import {
   commonDenoArgs,
@@ -109,4 +111,92 @@ await snapshotTest({
       await cleanup()
     }
   },
+})
+
+// Test validation: --public with no attachments is rejected before any work
+Deno.test("Issue Comment Add Command - rejects --public without --attach", async () => {
+  const errorLogs: string[] = []
+  const errorStub = stub(console, "error", (...args: unknown[]) => {
+    errorLogs.push(args.map(String).join(" "))
+  })
+  const exitStub = stub(Deno, "exit", (_code?: number) => {
+    throw new Error("EXIT")
+  })
+
+  try {
+    await commentAddCommand.parse(["TEST-123", "--body", "hi", "--public"])
+  } catch (e) {
+    // expected: handleError calls the stubbed Deno.exit which throws "EXIT"
+    if (!(e instanceof Error) || e.message !== "EXIT") throw e
+  } finally {
+    errorStub.restore()
+    exitStub.restore()
+  }
+
+  assertEquals(
+    errorLogs.some((l) =>
+      l.includes("--public requires at least one --attach")
+    ),
+    true,
+  )
+})
+
+// Test validation: with --public, an unsupported file anywhere in the batch is
+// rejected before ANY attachment uploads — an earlier valid image must not be
+// published first. The mock server has no FileUpload handler, so if the image
+// were uploaded the failure would be an upload error ("Failed to get upload
+// URL"), not this validation error. Seeing the validation error proves the
+// whole batch was rejected up front, before any network call.
+Deno.test("Issue Comment Add Command - rejects --public batch before uploading earlier valid images", async () => {
+  const imageFile = await Deno.makeTempFile({ suffix: ".png" })
+  const textFile = await Deno.makeTempFile({ suffix: ".txt" })
+  await Deno.writeTextFile(imageFile, "pretend png")
+  await Deno.writeTextFile(textFile, "not an image")
+
+  // No FileUpload handler: any actual upload attempt errors instead of hitting
+  // real Linear, and produces a different message than the validation error.
+  const { cleanup } = await setupMockLinearServer([])
+
+  const infoLogs: string[] = []
+  const errorLogs: string[] = []
+  const logStub = stub(console, "log", (...args: unknown[]) => {
+    infoLogs.push(args.map(String).join(" "))
+  })
+  const errorStub = stub(console, "error", (...args: unknown[]) => {
+    errorLogs.push(args.map(String).join(" "))
+  })
+  const exitStub = stub(Deno, "exit", (_code?: number) => {
+    throw new Error("EXIT")
+  })
+
+  try {
+    await commentAddCommand.parse([
+      "TEST-123",
+      "--attach",
+      imageFile, // valid raster image, listed first
+      "--attach",
+      textFile, // unsupported for --public, listed second
+      "--public",
+    ])
+  } catch (e) {
+    // expected: validation fails before any network upload
+    if (!(e instanceof Error) || e.message !== "EXIT") throw e
+  } finally {
+    logStub.restore()
+    errorStub.restore()
+    exitStub.restore()
+    await cleanup()
+    await Deno.remove(imageFile)
+    await Deno.remove(textFile)
+  }
+
+  // The batch is rejected with the validation error...
+  assertEquals(
+    errorLogs.some((l) =>
+      l.includes("Cannot upload text/plain to a public URL")
+    ),
+    true,
+  )
+  // ...and no attachment was uploaded (no "✓ Uploaded" line was printed).
+  assertEquals(infoLogs.some((l) => l.includes("Uploaded")), false)
 })


### PR DESCRIPTION
Draft follow-up to #234. **Do not merge before #234** — until then this branch also contains #234's commits, so its first CI run diffs the *superset* (contributor changes + this delta) against `main`. Once #234 lands, this will be rebased down to just the delta below.

#234 makes attachment uploads private by default and adds a `--public` opt-in that errors (rather than silently downgrades) for non-image types. Two gaps remained in `linear issue comment add`, both surfaced independently while blind-planning the fix:

- **Partial-upload on a mixed public batch.** `resolveMakePublic` only ran *inside* `uploadFile`, per file, at upload time. `comment add -a a.png -a b.pdf --public` would upload `a.png` **publicly** before `b.pdf` threw — a partial, and unwanted-public, upload. This pre-flights `resolveMakePublic` for every attachment in the existing existence-validation loop, so a mixed batch fails before anything is uploaded.
- **`--public` with no `--attach`** was a silent no-op. Per the repo's "explicit invalid input should error" convention, it's now a `ValidationError`.

Adds command-level tests for both paths (they short-circuit before any network call; the batch test runs against a handler-less mock server and asserts no upload occurred, so it genuinely fails if the pre-flight is removed).

No GraphQL documents changed, so no codegen. `deno check`, `deno lint`, `deno fmt`, and the test suite pass (the only failing test locally is the macOS keychain integration test, which needs interactive keychain access).

Credit to @tjmgregory for #234 — this is a small companion correction, not a replacement.