### PR TITLE
Follow-up to #228: fail loudly on inconsistent --all pagination

### DIFF
--- a/src/commands/milestone/milestone-view.ts
+++ b/src/commands/milestone/milestone-view.ts
@@ -4,7 +4,7 @@ import { gql } from "../../__codegen__/gql.ts"
 import { getGraphQLClient } from "../../utils/graphql.ts"
 import { formatRelativeTime } from "../../utils/display.ts"
 import { shouldShowSpinner } from "../../utils/hyperlink.ts"
-import { handleError, NotFoundError } from "../../utils/errors.ts"
+import { CliError, handleError, NotFoundError } from "../../utils/errors.ts"
 
 const PAGE_SIZE = 50
 const LIST_PREVIEW = 10
@@ -81,14 +81,28 @@ export const viewCommand = new Command()
       let pageInfo = milestone.issues.pageInfo
 
       if (all) {
-        while (pageInfo.hasNextPage && pageInfo.endCursor) {
+        // Paginate the full set. Fail loudly on inconsistent pagination rather
+        // than silently returning a partial list — silently dropping issues is
+        // the exact bug --all exists to prevent.
+        while (pageInfo.hasNextPage) {
+          if (!pageInfo.endCursor) {
+            throw new CliError(
+              "Linear reported more issues but returned no pagination cursor",
+              {
+                suggestion:
+                  `Retry, or use \`linear issue query --milestone ${milestone.id} --json\` for the full list.`,
+              },
+            )
+          }
           const nextPage = await client.request(GetMilestoneDetails, {
             id: milestoneId,
             first: PAGE_SIZE,
             after: pageInfo.endCursor,
           })
           const next = nextPage.projectMilestone
-          if (next == null) break
+          if (next == null) {
+            throw new NotFoundError("Milestone", milestoneId)
+          }
           issues.push(...next.issues.nodes)
           pageInfo = next.issues.pageInfo
         }
@@ -178,12 +192,16 @@ export const viewCommand = new Command()
           if (truncated) {
             lines.push("")
             lines.push(
-              `_Showing ${Math.min(LIST_PREVIEW, fetched)} of ${fetched}+ issues — the milestone contains more than ${PAGE_SIZE}. Re-run with \`--all\` or use \`linear issue query --milestone ${milestone.id} --json\` for the full list._`,
+              `_Showing ${
+                Math.min(LIST_PREVIEW, fetched)
+              } of ${fetched}+ issues — the milestone contains more than ${PAGE_SIZE}. Re-run with \`--all\` or use \`linear issue query --milestone ${milestone.id} --json\` for the full list._`,
             )
           } else if (hiddenLoaded > 0) {
             lines.push("")
             lines.push(
-              `_...and ${hiddenLoaded} more issue${hiddenLoaded === 1 ? "" : "s"}. Re-run with \`--all\` or use \`linear issue query --milestone ${milestone.id} --json\` to see them all._`,
+              `_...and ${hiddenLoaded} more issue${
+                hiddenLoaded === 1 ? "" : "s"
+              }. Re-run with \`--all\` or use \`linear issue query --milestone ${milestone.id} --json\` to see them all._`,
             )
           }
         }

--- a/test/commands/milestone/__snapshots__/milestone-view.test.ts.snap
+++ b/test/commands/milestone/__snapshots__/milestone-view.test.ts.snap
@@ -121,8 +121,8 @@ stdout:
 **Project:** P (p)
 **Project URL:** https://linear.app/test/project/p
 
-**Created:** 12/31/2019
-**Updated:** 1/1/2020
+**Created:** 1/1/2020
+**Updated:** 1/2/2020
 
 ## Issues
 
@@ -157,8 +157,8 @@ stdout:
 **Project:** P (p)
 **Project URL:** https://linear.app/test/project/p
 
-**Created:** 12/31/2019
-**Updated:** 1/1/2020
+**Created:** 1/1/2020
+**Updated:** 1/2/2020
 
 ## Issues
 

--- a/test/commands/milestone/milestone-view.test.ts
+++ b/test/commands/milestone/milestone-view.test.ts
@@ -1,4 +1,6 @@
 import { snapshotTest } from "@cliffy/testing"
+import { assertEquals } from "@std/assert"
+import { stub } from "@std/testing/mock"
 import { viewCommand } from "../../../src/commands/milestone/milestone-view.ts"
 import { commonDenoArgs } from "../../utils/test-helpers.ts"
 import { MockLinearServer } from "../../utils/mock_linear_server.ts"
@@ -220,8 +222,8 @@ await snapshotTest({
               description: null,
               targetDate: null,
               sortOrder: 1,
-              createdAt: "2020-01-01T00:00:00Z",
-              updatedAt: "2020-01-02T00:00:00Z",
+              createdAt: "2020-01-01T12:00:00Z",
+              updatedAt: "2020-01-02T12:00:00Z",
               project: {
                 id: "project-1",
                 name: "P",
@@ -282,8 +284,8 @@ await snapshotTest({
               description: null,
               targetDate: null,
               sortOrder: 1,
-              createdAt: "2020-01-01T00:00:00Z",
-              updatedAt: "2020-01-02T00:00:00Z",
+              createdAt: "2020-01-01T12:00:00Z",
+              updatedAt: "2020-01-02T12:00:00Z",
               project: {
                 id: "project-1",
                 name: "P",
@@ -314,8 +316,8 @@ await snapshotTest({
               description: null,
               targetDate: null,
               sortOrder: 1,
-              createdAt: "2020-01-01T00:00:00Z",
-              updatedAt: "2020-01-02T00:00:00Z",
+              createdAt: "2020-01-01T12:00:00Z",
+              updatedAt: "2020-01-02T12:00:00Z",
               project: {
                 id: "project-1",
                 name: "P",
@@ -349,4 +351,78 @@ await snapshotTest({
       Deno.env.delete("LINEAR_API_KEY")
     }
   },
+})
+
+// --all must fail loudly, not silently truncate, when Linear advertises another
+// page but returns no cursor to fetch it. (Regression guard for the exact bug
+// this command fixes: silently dropping issues.)
+Deno.test("Milestone View Command - --all errors on inconsistent pagination", async () => {
+  const server = new MockLinearServer([
+    {
+      queryName: "GetMilestoneDetails",
+      variables: { id: "milestone-bad", first: 50 },
+      response: {
+        data: {
+          projectMilestone: {
+            id: "milestone-bad",
+            name: "Broken Pagination",
+            description: null,
+            targetDate: null,
+            sortOrder: 1,
+            createdAt: "2020-01-01T12:00:00Z",
+            updatedAt: "2020-01-02T12:00:00Z",
+            project: {
+              id: "project-1",
+              name: "P",
+              slugId: "p",
+              url: "https://linear.app/test/project/p",
+            },
+            issues: {
+              nodes: Array.from({ length: 50 }, (_, i) => ({
+                id: `id-${i}`,
+                identifier: `BAD-${i + 1}`,
+                title: `Issue ${i + 1}`,
+                state: { name: "Done", type: "completed" },
+              })),
+              // hasNextPage true but no cursor: continuing is impossible.
+              pageInfo: { hasNextPage: true, endCursor: null },
+            },
+          },
+        },
+      },
+    },
+  ])
+
+  const errorLogs: string[] = []
+  const errorStub = stub(console, "error", (...args: unknown[]) => {
+    errorLogs.push(args.map(String).join(" "))
+  })
+  const exitStub = stub(Deno, "exit", (_code?: number) => {
+    throw new Error("EXIT")
+  })
+
+  let exited = false
+  try {
+    await server.start()
+    Deno.env.set("LINEAR_GRAPHQL_ENDPOINT", server.getEndpoint())
+    Deno.env.set("LINEAR_API_KEY", "Bearer test-token")
+    await viewCommand.parse(["milestone-bad", "--all"])
+  } catch (e) {
+    if (!(e instanceof Error) || e.message !== "EXIT") throw e
+    exited = true
+  } finally {
+    errorStub.restore()
+    exitStub.restore()
+    await server.stop()
+    Deno.env.delete("LINEAR_GRAPHQL_ENDPOINT")
+    Deno.env.delete("LINEAR_API_KEY")
+  }
+
+  assertEquals(exited, true)
+  assertEquals(
+    errorLogs.some((l) =>
+      l.includes("more issues but returned no pagination cursor")
+    ),
+    true,
+  )
 })


### PR DESCRIPTION
Draft follow-up to #228. **Do not merge before #228** — until then this branch also contains #228's commit, so its first CI run diffs the superset against `main`. Rebased down to just the delta once #228 lands.

#228 fixes `milestone view` silently capping its issue list and adds `--all` to paginate the full set. The `--all` loop guarded on `while (pageInfo.hasNextPage && pageInfo.endCursor)` and `if (next == null) break`, so if Linear advertised another page but returned no cursor, or the milestone disappeared mid-pagination, `--all` would stop early and return a **partial** list with no error — quietly reintroducing the exact silent-truncation bug the command exists to fix.

- `--all` now throws a `CliError` when `hasNextPage` is true but no cursor is returned, and a `NotFoundError` if the milestone vanishes mid-pagination.
- Adds a regression test (a `hasNextPage`-without-cursor first page errors rather than rendering a truncated list). Verified it fails against the un-hardened loop.

No change to default (non-`--all`) behavior — the new checks run only inside `if (all)`. Credit to @jrschumacher for #228.