### PR TITLE
Follow-up to #235: exclude resolved inline comments from the update guard

### DIFF
--- a/src/commands/document/document-update.ts
+++ b/src/commands/document/document-update.ts
@@ -1,5 +1,6 @@
 import { Command } from "@cliffy/command"
 import { gql } from "../../__codegen__/gql.ts"
+import type { DocumentInlineCommentGuardQuery } from "../../__codegen__/graphql.ts"
 import { getGraphQLClient } from "../../utils/graphql.ts"
 import { getEditor } from "../../utils/editor.ts"
 import { readIdsFromStdin } from "../../utils/bulk.ts"
@@ -28,6 +29,8 @@ const DocumentInlineCommentGuard = gql(`
         nodes {
           id
           quotedText
+          resolvedAt
+          archivedAt
         }
         pageInfo {
           hasNextPage
@@ -38,42 +41,33 @@ const DocumentInlineCommentGuard = gql(`
   }
 `)
 
-interface DocumentInlineComment {
-  id: string
-  quotedText?: string | null
-}
-
-interface DocumentInlineCommentGuardResponse {
-  document?: {
-    comments: {
-      nodes: DocumentInlineComment[]
-      pageInfo: {
-        hasNextPage: boolean
-        endCursor?: string | null
-      }
-    }
-  } | null
-}
-
-async function getFirstInlineDocumentComment(
+// An inline comment (quotedText != null) still anchored to live text — i.e. not
+// resolved and not archived — is the only kind a content replacement can
+// meaningfully orphan. Resolved/archived threads are closed, so detaching their
+// anchor loses nothing and must not block the update.
+async function getFirstActiveInlineComment(
   client: ReturnType<typeof getGraphQLClient>,
   documentId: string,
 ) {
   let after: string | null | undefined = null
 
   while (true) {
-    const documentData: DocumentInlineCommentGuardResponse = await client
-      .request(DocumentInlineCommentGuard, {
-        id: documentId,
-        after,
-      })
+    // Annotate with the codegen type: reusing `after` across iterations would
+    // otherwise make the request's result type circular (self-referential).
+    const documentData: DocumentInlineCommentGuardQuery = await client.request(
+      DocumentInlineCommentGuard,
+      { id: documentId, after },
+    )
 
-    if (!documentData?.document) {
+    if (!documentData.document) {
       throw new NotFoundError("Document", documentId)
     }
 
-    const comments = documentData.document.comments.nodes
-    const inlineComment = comments.find((comment) => comment.quotedText)
+    const inlineComment = documentData.document.comments.nodes.find(
+      (comment) =>
+        comment.quotedText != null && comment.resolvedAt == null &&
+        comment.archivedAt == null,
+    )
     if (inlineComment) {
       return inlineComment
     }
@@ -281,7 +275,7 @@ export const updateCommand = new Command()
         }
 
         if (input.content !== undefined && !force) {
-          const comment = await getFirstInlineDocumentComment(
+          const comment = await getFirstActiveInlineComment(
             client,
             documentId,
           )

--- a/test/commands/document/__snapshots__/document-update.test.ts.snap
+++ b/test/commands/document/__snapshots__/document-update.test.ts.snap
@@ -86,3 +86,12 @@ stderr:
   Use --title, --content, --content-file, --icon, or --edit.
 "
 `;
+
+snapshot[`Document Update Command - Resolved Inline Comment Does Not Block 1`] = `
+stdout:
+"✓ Updated document: Delegation System Spec
+https://linear.app/test/document/delegation-system-spec-d4b93e3b2695
+"
+stderr:
+""
+`;

--- a/test/commands/document/document-update.test.ts
+++ b/test/commands/document/document-update.test.ts
@@ -444,3 +444,75 @@ await snapshotTest({
 })
 
 // NOTE: "Permission Error" test removed - stack traces contain machine-specific paths
+
+// A RESOLVED inline comment (closed thread) must NOT block a content update:
+// detaching the anchor of a resolved comment loses no live context, so the
+// guard should let the update through without --force.
+await snapshotTest({
+  name: "Document Update Command - Resolved Inline Comment Does Not Block",
+  meta: import.meta,
+  colors: false,
+  args: ["d4b93e3b2695", "--content", "# Updated Content"],
+  denoArgs: commonDenoArgs,
+  async fn() {
+    const server = new MockLinearServer([
+      {
+        queryName: "DocumentInlineCommentGuard",
+        variables: { id: "d4b93e3b2695" },
+        response: {
+          data: {
+            document: {
+              id: "doc-1",
+              comments: {
+                nodes: [
+                  {
+                    // Inline (has quotedText) but resolved: must be ignored.
+                    id: "comment-resolved",
+                    quotedText: "Old anchored text",
+                    resolvedAt: "2026-01-15T10:00:00Z",
+                    archivedAt: null,
+                  },
+                ],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          },
+        },
+      },
+      {
+        queryName: "UpdateDocument",
+        variables: {
+          id: "d4b93e3b2695",
+          input: { content: "# Updated Content" },
+        },
+        response: {
+          data: {
+            documentUpdate: {
+              success: true,
+              document: {
+                id: "doc-1",
+                slugId: "d4b93e3b2695",
+                title: "Delegation System Spec",
+                url:
+                  "https://linear.app/test/document/delegation-system-spec-d4b93e3b2695",
+                updatedAt: "2026-01-19T10:00:00Z",
+              },
+            },
+          },
+        },
+      },
+    ])
+
+    try {
+      await server.start()
+      Deno.env.set("LINEAR_GRAPHQL_ENDPOINT", server.getEndpoint())
+      Deno.env.set("LINEAR_API_KEY", "Bearer test-token")
+
+      await updateCommand.parse()
+    } finally {
+      await server.stop()
+      Deno.env.delete("LINEAR_GRAPHQL_ENDPOINT")
+      Deno.env.delete("LINEAR_API_KEY")
+    }
+  },
+})


### PR DESCRIPTION
Draft follow-up to #235. **Do not merge before #235** — until then this branch also contains #235's commits (first CI diffs the superset). Rebased to just the delta once #235 lands (squash).

#235 makes `document update` refuse a content replacement when the document has active inline comments (whose anchors it could orphan), with `--force` to override, and exposes comments in `document view --json`. Two corrections to the update guard:

- **Exclude resolved/archived inline comments.** The guard query only selected `quotedText`, so it blocked on *any* inline comment — including resolved (closed) threads, whose anchor detaching loses no live context. It now selects `resolvedAt`/`archivedAt` and ignores resolved/archived comments, so a closed thread no longer forces `--force`. (Both independent design passes flagged this; the `view` side already fetched `resolvedAt`.)
- **Use the codegen type instead of hand-written interfaces.** Replaced the hand-written `DocumentInlineComment*` interfaces with the generated `DocumentInlineCommentGuardQuery` type (repo convention: no `any`, typed GraphQL). The annotation also breaks the circular result-type inference the reused `after` cursor introduced — which is why the hand-written interface existed.

Adds a test that a resolved inline comment lets the update proceed without `--force` (verified it fails against the un-fixed guard). Credit to @josephyooo for #235.