### PR TITLE
Follow-up to #170: cover labels on the with-comments query path

### DIFF
--- a/test/commands/issue/__snapshots__/issue-view.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-view.test.ts.snap
@@ -484,3 +484,64 @@ stdout:
 stderr:
 ""
 `;
+
+snapshot[`Issue View Command - JSON Output With Labels And Comments 1`] = `
+stdout:
+'{
+  "identifier": "TEST-123",
+  "title": "Fix authentication bug in login flow",
+  "description": "Users are experiencing issues logging in when their session expires.",
+  "url": "https://linear.app/test-team/issue/TEST-123/fix-authentication-bug-in-login-flow",
+  "branchName": "fix/test-123-auth-bug",
+  "state": {
+    "name": "In Progress",
+    "color": "#f87462"
+  },
+  "assignee": {
+    "name": "jane.smith",
+    "displayName": "Jane Smith"
+  },
+  "priority": 2,
+  "project": null,
+  "projectMilestone": null,
+  "parent": null,
+  "children": {
+    "nodes": []
+  },
+  "labels": {
+    "nodes": [
+      {
+        "id": "label-1",
+        "name": "bug",
+        "color": "#e5484d"
+      },
+      {
+        "id": "label-2",
+        "name": "priority:high",
+        "color": "#f5a524"
+      }
+    ]
+  },
+  "comments": {
+    "nodes": [
+      {
+        "id": "comment-1",
+        "body": "Reproduced on staging.",
+        "createdAt": "2024-01-15T10:30:00Z",
+        "user": {
+          "name": "john.doe",
+          "displayName": "John Doe"
+        },
+        "externalUser": null,
+        "parent": null
+      }
+    ]
+  },
+  "attachments": {
+    "nodes": []
+  }
+}
+'
+stderr:
+""
+`;

--- a/test/commands/issue/issue-view.test.ts
+++ b/test/commands/issue/issue-view.test.ts
@@ -1258,3 +1258,94 @@ await snapshotTest({
     }
   },
 })
+
+// Labels must also surface via the with-comments query path (GetIssueDetailsWithComments),
+// not only the --no-comments path. Complements the existing "JSON Output With Labels"
+// (which exercises GetIssueDetails) so both fetchIssueDetailsRaw code paths are covered.
+await snapshotTest({
+  name: "Issue View Command - JSON Output With Labels And Comments",
+  meta: import.meta,
+  colors: false,
+  args: ["TEST-123", "--json"],
+  denoArgs,
+  async fn() {
+    const server = new MockLinearServer([
+      {
+        queryName: "GetIssueDetailsWithComments",
+        variables: { id: "TEST-123" },
+        response: {
+          data: {
+            issue: {
+              identifier: "TEST-123",
+              title: "Fix authentication bug in login flow",
+              description:
+                "Users are experiencing issues logging in when their session expires.",
+              url:
+                "https://linear.app/test-team/issue/TEST-123/fix-authentication-bug-in-login-flow",
+              branchName: "fix/test-123-auth-bug",
+              state: {
+                name: "In Progress",
+                color: "#f87462",
+              },
+              assignee: {
+                name: "jane.smith",
+                displayName: "Jane Smith",
+              },
+              priority: 2,
+              project: null,
+              projectMilestone: null,
+              parent: null,
+              children: {
+                nodes: [],
+              },
+              labels: {
+                nodes: [
+                  {
+                    id: "label-1",
+                    name: "bug",
+                    color: "#e5484d",
+                  },
+                  {
+                    id: "label-2",
+                    name: "priority:high",
+                    color: "#f5a524",
+                  },
+                ],
+              },
+              comments: {
+                nodes: [
+                  {
+                    id: "comment-1",
+                    body: "Reproduced on staging.",
+                    createdAt: "2024-01-15T10:30:00Z",
+                    user: {
+                      name: "john.doe",
+                      displayName: "John Doe",
+                    },
+                    externalUser: null,
+                    parent: null,
+                  },
+                ],
+              },
+              attachments: {
+                nodes: [],
+              },
+            },
+          },
+        },
+      },
+    ])
+
+    try {
+      await server.start()
+      Deno.env.set("LINEAR_GRAPHQL_ENDPOINT", server.getEndpoint())
+      Deno.env.set("LINEAR_API_KEY", "Bearer test-token")
+
+      await viewCommand.parse()
+    } finally {
+      await server.stop()
+      Deno.env.delete("LINEAR_GRAPHQL_ENDPOINT")
+      Deno.env.delete("LINEAR_API_KEY")
+    }
+  },
+})


### PR DESCRIPTION
Draft follow-up to #170. **Do not merge before #170.** #170's branch was conflicting with `main` (it predated a refactor that moved `fetchIssueDetails`' return type to the codegen-derived `FetchedIssueDetails` and evolved the issue-detail queries); I resolved it by merging current `main` into the PR branch — taking main's structure and re-applying the `labels` selection to both queries — and pushed that merge to the fork, so #170 is mergeable again.

This follow-up adds one test: #170 selects `labels` in both `GetIssueDetails` and `GetIssueDetailsWithComments`, but its labels-with-content test only exercised the `--no-comments` (`GetIssueDetails`) path. This adds a `--json` (with comments) test carrying real labels so **both** `fetchIssueDetailsRaw` paths are verified to surface labels — the consistency both were meant to guarantee.

Credit to @RengarLee for #170.