### PR TITLE
Follow-up to #236: fail hard on fmt errors, trim abort output, render SKILL.md first

### DIFF
--- a/skills/linear-cli/scripts/generate-docs.ts
+++ b/skills/linear-cli/scripts/generate-docs.ts
@@ -324,13 +324,15 @@ async function main() {
 
   const commands = discovered.map((result) => result.command).sort(byName)
 
+  // Render SKILL.md from its template before writing anything, so a missing or
+  // broken template aborts before writeReferences prunes any stale docs.
+  console.log("Generating SKILL.md from template...")
+  const skillContent = await generateSkillMd(commands)
+
   // Generate markdown files
   console.log("Generating markdown files...")
   await writeReferences(commands)
 
-  // Generate SKILL.md from template
-  console.log("Generating SKILL.md from template...")
-  const skillContent = await generateSkillMd(commands)
   await Deno.writeTextFile(SKILL_MD, skillContent)
   console.log("  Generated: SKILL.md")
 
@@ -338,16 +340,23 @@ async function main() {
   console.log("\nFormatting generated files...")
   const fmtResult = await run(["deno", "fmt", SKILL_DIR])
   if (!fmtResult.success) {
-    console.error("Warning: Failed to format generated files")
-    console.error(fmtResult.stderr)
+    // Fail hard: unformatted docs would break `deno fmt --check` in CI once committed.
+    throw new Error(
+      `Failed to format generated files: ${
+        fmtResult.stderr || "unknown error"
+      }`,
+    )
   }
 
   console.log(`\nDone! Generated ${commands.length + 2} files.`)
 }
 
 if (import.meta.main) {
-  main().catch((error) => {
-    console.error(error)
+  main().catch((error: unknown) => {
+    // Print a concise message, not a raw stack trace, on any abort path.
+    console.error(
+      `Error: ${error instanceof Error ? error.message : String(error)}`,
+    )
     Deno.exit(1)
   })
 }


### PR DESCRIPTION
Follow-up to #236. A small corrective delta stacked on top of that PR's generator hardening; it will be rebased down to only the delta once #236 lands.

This delta was blind-planned: two independent planners designed the generator fix from a solution-stripped problem statement (without seeing #236), and both independently flagged the three gaps below that #236 left open.

### What this changes in `skills/linear-cli/scripts/generate-docs.ts`
- **`deno fmt` failure is now fatal** instead of a logged warning. The format step runs after the docs are written, so a silent failure would leave unformatted docs that break `deno fmt --check` in CI once committed.
- **The top-level error boundary prints a concise message** (`Error: <message>`) instead of the raw error object and its stack trace, on every abort path (missing binary, failed help fetch, fmt failure).
- **`SKILL.md` is rendered from its template before `writeReferences` prunes any stale docs**, so a missing or broken template aborts before the references directory is touched — extending #236's own "write before prune / abort before write" invariant to the template read.

None of these change the generated doc output — they are pure control-flow/error-handling. `deno task generate-skill-docs` remains idempotent.

> Note: while this branch is a draft it still contains #236's commits. The first CI run therefore diffs the superset (#236 + this delta) against `main`; after #236 merges, this will be rebased to only the delta and marked ready.