### PR TITLE
Add `issue update --unassign` to clear an issue's assignee

### DIFF
--- a/skills/linear-cli/references/issue.md
+++ b/skills/linear-cli/references/issue.md
@@ -583,6 +583,7 @@ Options:
   -h, --help                         - Show this help.                                                                             
   --workspace         <slug>         - Target workspace (uses credentials)                                                         
   -a, --assignee      <assignee>     - Assign the issue to 'self' or someone (by username or name)                                 
+  --unassign                         - Clear the issue's assignee (cannot be combined with --assignee)                             
   --due-date          <dueDate>      - Due date of the issue                                                                       
   --parent            <parent>       - Parent issue (if any) as a team_number code                                                 
   -p, --priority      <priority>     - Priority of the issue (1-4, descending priority)                                            

--- a/src/commands/issue/issue-update.ts
+++ b/src/commands/issue/issue-update.ts
@@ -1,5 +1,6 @@
 import { Command } from "@cliffy/command"
 import { gql } from "../../__codegen__/gql.ts"
+import type { IssueUpdateInput } from "../../__codegen__/graphql.ts"
 import { getGraphQLClient } from "../../utils/graphql.ts"
 import { getTeamKeyFromIssueIdentifier } from "../../utils/issue-identifier.ts"
 import {
@@ -31,6 +32,10 @@ export const updateCommand = new Command()
   .option(
     "-a, --assignee <assignee:string>",
     "Assign the issue to 'self' or someone (by username or name)",
+  )
+  .option(
+    "--unassign",
+    "Clear the issue's assignee (cannot be combined with --assignee)",
   )
   .option(
     "--due-date <dueDate:string>",
@@ -86,6 +91,7 @@ export const updateCommand = new Command()
     async (
       {
         assignee,
+        unassign,
         dueDate,
         parent,
         priority,
@@ -103,6 +109,16 @@ export const updateCommand = new Command()
       issueIdArg,
     ) => {
       try {
+        if (unassign && assignee != null) {
+          throw new ValidationError(
+            "Cannot specify both --assignee and --unassign",
+            {
+              suggestion:
+                "Use --assignee <user> to set an assignee, or --unassign on its own to clear it.",
+            },
+          )
+        }
+
         // Validate that description and descriptionFile are not both provided
         if (description && descriptionFile) {
           throw new ValidationError(
@@ -180,7 +196,7 @@ export const updateCommand = new Command()
           }
         }
 
-        const labelIds = []
+        const labelIds: string[] = []
         if (labels != null && labels.length > 0) {
           for (const label of labels) {
             const labelId = await getIssueLabelIdByNameForTeam(label, teamKey)
@@ -230,11 +246,17 @@ export const updateCommand = new Command()
           cycleId = await getCycleIdByNameOrNumber(cycle, teamId)
         }
 
-        // Build the update input object, only including fields that were provided
-        const input: Record<string, string | number | string[] | undefined> = {}
+        // Build the update input object, only including fields that were provided.
+        // Clearing a field requires an explicit flag (see --unassign); never set
+        // a field to null implicitly.
+        const input: IssueUpdateInput = {}
 
         if (title !== undefined) input.title = title
-        if (assigneeId !== undefined) input.assigneeId = assigneeId
+        if (unassign) {
+          input.assigneeId = null
+        } else if (assigneeId != null) {
+          input.assigneeId = assigneeId
+        }
         if (dueDate !== undefined) input.dueDate = dueDate
         if (parent !== undefined) {
           const parentIdentifier = await getIssueIdentifier(parent)

--- a/test/commands/issue/__snapshots__/issue-update.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-update.test.ts.snap
@@ -13,6 +13,7 @@ Options:
 
   -h, --help                         - Show this help.                                                                  
   -a, --assignee      <assignee>     - Assign the issue to 'self' or someone (by username or name)                      
+  --unassign                         - Clear the issue's assignee (cannot be combined with --assignee)                  
   --due-date          <dueDate>      - Due date of the issue                                                            
   --parent            <parent>       - Parent issue (if any) as a team_number code                                      
   -p, --priority      <priority>     - Priority of the issue (1-4, descending priority)                                 
@@ -129,3 +130,46 @@ stderr:
   Valid states: \\"Todo\\" (unstarted), \\"In Progress\\" (started), \\"Done\\" (completed). Run \`linear team states ENG\` to list them.
 "
 `;
+
+snapshot[`Issue Update Command - Unassign Clears Assignee 1`] = `
+stdout:
+"Updating issue ENG-123
+
+✓ Updated issue ENG-123: Some issue
+https://linear.app/test-team/issue/ENG-123/some-issue
+"
+stderr:
+""
+`;
+
+snapshot[`Issue Update Command - Unassign With Other Fields 1`] = `
+stdout:
+"Updating issue ENG-123
+
+✓ Updated issue ENG-123: Renamed
+https://linear.app/test-team/issue/ENG-123/renamed
+"
+stderr:
+""
+`;
+
+snapshot[`Issue Update Command - Assignee Still Sends User Id 1`] = `
+stdout:
+"Updating issue ENG-123
+
+✓ Updated issue ENG-123: Some issue
+https://linear.app/test-team/issue/ENG-123/some-issue
+"
+stderr:
+""
+`;
+
+snapshot[`Issue Update Command - Assignee And Unassign Conflict 1`] = `
+stdout:
+""
+stderr:
+"✗ Failed to update issue: Cannot specify both --assignee and --unassign
+  Use --assignee <user> to set an assignee, or --unassign on its own to clear it.
+"
+`;
+

--- a/test/commands/issue/issue-update.test.ts
+++ b/test/commands/issue/issue-update.test.ts
@@ -567,3 +567,172 @@ await snapshotTest({
     }
   },
 })
+
+// --unassign must send `assigneeId: null` on the wire. The mock's `input` is
+// matched with an exact key-count comparison (mock_linear_server.ts deepEqual),
+// so this only matches if assigneeId is present AND null: dropping to
+// `undefined` erases the key during JSON.stringify, and sending a user id
+// fails the value comparison. Do not relax `variables` to an unconstrained
+// mock — that would match any payload and prove nothing.
+await snapshotTest({
+  name: "Issue Update Command - Unassign Clears Assignee",
+  meta: import.meta,
+  colors: false,
+  args: ["ENG-123", "--unassign"],
+  denoArgs: commonDenoArgs,
+  async fn() {
+    const { cleanup } = await setupMockLinearServer([
+      {
+        queryName: "GetTeamIdByKey",
+        variables: { team: "ENG" },
+        response: { data: { teams: { nodes: [{ id: "team-eng-id" }] } } },
+      },
+      // No GetViewerId mock: --unassign must not perform a user lookup.
+      {
+        queryName: "UpdateIssue",
+        variables: {
+          id: "ENG-123",
+          input: { assigneeId: null, teamId: "team-eng-id" },
+        },
+        response: {
+          data: {
+            issueUpdate: {
+              success: true,
+              issue: {
+                id: "issue-existing-123",
+                identifier: "ENG-123",
+                url: "https://linear.app/test-team/issue/ENG-123/some-issue",
+                title: "Some issue",
+              },
+            },
+          },
+        },
+      },
+    ], { LINEAR_TEAM_ID: "ENG" })
+
+    try {
+      await updateCommand.parse()
+    } finally {
+      await cleanup()
+    }
+  },
+})
+
+// --unassign alongside another field: the null must not clobber, or be
+// clobbered by, sibling assignments.
+await snapshotTest({
+  name: "Issue Update Command - Unassign With Other Fields",
+  meta: import.meta,
+  colors: false,
+  args: ["ENG-123", "--unassign", "--title", "Renamed"],
+  denoArgs: commonDenoArgs,
+  async fn() {
+    const { cleanup } = await setupMockLinearServer([
+      {
+        queryName: "GetTeamIdByKey",
+        variables: { team: "ENG" },
+        response: { data: { teams: { nodes: [{ id: "team-eng-id" }] } } },
+      },
+      {
+        queryName: "UpdateIssue",
+        variables: {
+          id: "ENG-123",
+          input: {
+            title: "Renamed",
+            assigneeId: null,
+            teamId: "team-eng-id",
+          },
+        },
+        response: {
+          data: {
+            issueUpdate: {
+              success: true,
+              issue: {
+                id: "issue-existing-123",
+                identifier: "ENG-123",
+                url: "https://linear.app/test-team/issue/ENG-123/renamed",
+                title: "Renamed",
+              },
+            },
+          },
+        },
+      },
+    ], { LINEAR_TEAM_ID: "ENG" })
+
+    try {
+      await updateCommand.parse()
+    } finally {
+      await cleanup()
+    }
+  },
+})
+
+// Regression guard for the --assignee path: it must still send a string id.
+// The "Happy Path" test above cannot catch a break here because its
+// UpdateIssue mock declares no `variables` and matches any payload.
+await snapshotTest({
+  name: "Issue Update Command - Assignee Still Sends User Id",
+  meta: import.meta,
+  colors: false,
+  args: ["ENG-123", "--assignee", "self"],
+  denoArgs: commonDenoArgs,
+  async fn() {
+    const { cleanup } = await setupMockLinearServer([
+      {
+        queryName: "GetTeamIdByKey",
+        variables: { team: "ENG" },
+        response: { data: { teams: { nodes: [{ id: "team-eng-id" }] } } },
+      },
+      {
+        queryName: "GetViewerId",
+        variables: {},
+        response: { data: { viewer: { id: "user-self-123" } } },
+      },
+      {
+        queryName: "UpdateIssue",
+        variables: {
+          id: "ENG-123",
+          input: { assigneeId: "user-self-123", teamId: "team-eng-id" },
+        },
+        response: {
+          data: {
+            issueUpdate: {
+              success: true,
+              issue: {
+                id: "issue-existing-123",
+                identifier: "ENG-123",
+                url: "https://linear.app/test-team/issue/ENG-123/some-issue",
+                title: "Some issue",
+              },
+            },
+          },
+        },
+      },
+    ], { LINEAR_TEAM_ID: "ENG" })
+
+    try {
+      await updateCommand.parse()
+    } finally {
+      await cleanup()
+    }
+  },
+})
+
+// The conflict guard sits at the top of the action, so this must fail before
+// any HTTP. No mock server is configured on purpose: if the guard is ever
+// moved below the network calls, this fails with a connection error instead of
+// the validation message. The endpoint is pinned to a dead port so that
+// regression can never reach the real Linear API using inherited credentials.
+await snapshotTest({
+  name: "Issue Update Command - Assignee And Unassign Conflict",
+  meta: import.meta,
+  colors: false,
+  args: ["ENG-123", "--assignee", "self", "--unassign"],
+  denoArgs: commonDenoArgs,
+  canFail: true,
+  async fn() {
+    Deno.env.set("LINEAR_GRAPHQL_ENDPOINT", "http://127.0.0.1:1")
+    Deno.env.set("LINEAR_API_KEY", "Bearer test-token")
+    await updateCommand.parse()
+  },
+})


### PR DESCRIPTION
There was currently no way to unassign an issue.

## Root cause

The mutation input was built as `Record<string, string | number | string[] | undefined>` — a type that structurally cannot hold `null`. So `IssueUpdateInput.assigneeId` could never be set to `null`, no matter what flag was added on top. Adding a flag alone would not have compiled.

## Change

- Swap the hand-rolled `Record` for the codegen'd `IssueUpdateInput`. `project update` already does this (`project-update.ts:152`), so this restores consistency rather than introducing a pattern. Type check confirmed zero fallout across every existing field assignment.
- Add `--unassign`, which sends `assigneeId: null`.
- Passing both `--assignee` and `--unassign` raises a `ValidationError` with a suggestion, rather than one silently winning. The guard runs before any network or VCS call.

## No short alias

`-U, --unassigned` is already bound in three sibling commands (`issue-query.ts:73`, `issue-mine.ts:118`, `issue-start.ts:25`) as a read-side *filter*. Binding `-u, --unassign` would put a data-clearing mutation one shift-key from a harmless filter. Long-form only; an alias can be added later but never removed.

## Verification

Linear silently ignores `projectId: null` elsewhere in this codebase (`document-update.ts:214`), so mocked tests alone could not prove this works. Verified against the real API on a throwaway issue: assignee cleared, issue then deleted.

Tests assert the wire payload by pinning the mock's `input` to an exact shape, which is load-bearing — the mock matcher compares nested objects by exact key count, so a regression to `undefined` drops the key and fails to match. Confirmed by deliberately reverting the implementation and watching the tests fail.

## Follow-ups (not in this PR)

- The same nullable-clear gap exists for `--project`, `--cycle`, `--parent`, and `--milestone`. The type migration here unblocks each as roughly a one-liner.
- `issue create` still builds its input as a loose object rather than `IssueCreateInput`.
- Generated skill docs are not reproducible across machines: the generator's wrap width comes from `Deno.consoleSize()`, so regenerating on a different terminal reflows unrelated files. Only the real `--unassign` line is included here to avoid that churn.