### PR TITLE
Add `linear issue state` command

### DIFF
--- a/docs/cast-issue-create.svg
+++ b/docs/cast-issue-create.svg
@@ -12,7 +12,8 @@
     xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink"
   >
-    <style>@keyframes s {
+    <style>
+    @keyframes s {
       0% {
         transform: translateX(0);
       }
@@ -361,7 +362,9 @@
       font-weight: 700;
       text-decoration: underline;
     }
-    .d, .e, .f {
+    .d,
+    .e,
+    .f {
       fill: #586e75;
       white-space: pre;
     }
@@ -371,7 +374,9 @@
     .g {
       fill: #dbab79;
     }
-    .g, .h, .i {
+    .g,
+    .h,
+    .i {
       white-space: pre;
     }
     .h {
@@ -384,14 +389,17 @@
     .j {
       text-decoration: underline;
     }
-    .j, .k, .l {
+    .j,
+    .k,
+    .l {
       fill: #b9c0cb;
       white-space: pre;
     }
     .l {
       fill: #e88388;
     }
-    .m, .n {
+    .m,
+    .n {
       text-decoration: underline;
     }
     .m {
@@ -402,27 +410,34 @@
       fill: #b9c0cb;
       font-weight: 700;
     }
-    .n, .o, .u, .v {
+    .n,
+    .o,
+    .u,
+    .v {
       white-space: pre;
     }
     .o {
       fill: #73bef3;
       text-decoration: underline;
     }
-    .u, .v {
+    .u,
+    .v {
       fill: #93a1a1;
     }
     .v {
       fill: #657b83;
       font-weight: 700;
       text-decoration: underline;
-    }</style>
+    }
+    </style>
     <g
       font-family="Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace"
       font-size="1.67"
     >
       <defs>
-        <symbol id="1"><text y="1.67" class="c">❯</text></symbol>
+        <symbol id="1">
+          <text y="1.67" class="c">❯</text>
+        </symbol>
         <symbol
           id="2"
         >
@@ -1300,7 +1315,9 @@
           >0L,</text>
           <text x="75.15" y="1.67" class="k">0B</text>
         </symbol>
-        <symbol id="49"><text y="1.67" class="i">~</text></symbol>
+        <symbol id="49">
+          <text y="1.67" class="i">~</text>
+        </symbol>
         <symbol id="50">
           <text y="1.67" class="h">--</text>
           <text x="3.006" y="1.67" class="h">INSERT</text>
@@ -1310,7 +1327,9 @@
             class="h"
           >--</text>
         </symbol>
-        <symbol id="51"><text y="1.67" class="k">markdown</text></symbol>
+        <symbol id="51">
+          <text y="1.67" class="k">markdown</text>
+        </symbol>
         <symbol id="52">
           <text y="1.67" class="k">markdown</text>
           <text x="9.018" y="1.67" class="k">descri</text>
@@ -1327,7 +1346,9 @@
           <text y="1.67" class="k">markdown</text>
           <text x="9.018" y="1.67" class="k">description</text>
         </symbol>
-        <symbol id="56"><text y="1.67" class="k">:wq</text></symbol>
+        <symbol id="56">
+          <text y="1.67" class="k">:wq</text>
+        </symbol>
         <symbol id="57">
           <text y="1.67" class="j">Description</text>
           <text x="12.024" y="1.67" class="j">entered</text>

--- a/docs/cast-issue-start.svg
+++ b/docs/cast-issue-start.svg
@@ -12,7 +12,8 @@
     xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink"
   >
-    <style>@keyframes n {
+    <style>
+    @keyframes n {
       0% {
         transform: translateX(0);
       }
@@ -149,7 +150,8 @@
     .a {
       fill: #282d35;
     }
-    .c, .d {
+    .c,
+    .d {
       fill: #a8cc8c;
       white-space: pre;
     }
@@ -160,14 +162,17 @@
       font-weight: 700;
       text-decoration: underline;
     }
-    .e, .f {
+    .e,
+    .f {
       fill: #657b83;
       white-space: pre;
     }
     .g {
       fill: #dbab79;
     }
-    .g, .h, .i {
+    .g,
+    .h,
+    .i {
       white-space: pre;
     }
     .h {
@@ -180,7 +185,9 @@
     .j {
       fill: #b9c0cb;
     }
-    .j, .k, .q {
+    .j,
+    .k,
+    .q {
       white-space: pre;
     }
     .k {
@@ -190,13 +197,16 @@
     }
     .q {
       fill: #93a1a1;
-    }</style>
+    }
+    </style>
     <g
       font-family="Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace"
       font-size="1.67"
     >
       <defs>
-        <symbol id="1"><text y="1.67" class="c">❯</text></symbol>
+        <symbol id="1">
+          <text y="1.67" class="c">❯</text>
+        </symbol>
         <symbol
           id="2"
         >
@@ -421,7 +431,9 @@
             class="c"
           >issues</text>
         </symbol>
-        <symbol id="11"><text y="1.67" class="j">⠋</text></symbol>
+        <symbol id="11">
+          <text y="1.67" class="j">⠋</text>
+        </symbol>
         <symbol id="12">
           <text y="1.67" class="g">?</text>
           <text x="2.004" y="1.67" class="h">Branch</text>

--- a/skills/linear-cli/SKILL.md
+++ b/skills/linear-cli/SKILL.md
@@ -192,6 +192,7 @@ linear issue relation add
 linear issue relation delete
 linear issue relation list
 linear issue start
+linear issue state
 linear issue title
 linear issue update
 linear issue url

--- a/skills/linear-cli/references/api.md
+++ b/skills/linear-cli/references/api.md
@@ -13,11 +13,10 @@ Description:
 
 Options:
 
-  -h, --help                    - Show this help.                                                                  
-  --workspace       <slug>      - Target workspace (uses credentials)                                              
-  --variable        <variable>  - Variable in key=value format (coerces booleans, numbers, null; @file reads from  
-                                  path)                                                                            
-  --variables-json  <json>      - JSON object of variables (merged with --variable, which takes precedence)        
-  --paginate                    - Auto-paginate a single connection field using cursor pagination                  
+  -h, --help                    - Show this help.                                                                        
+  --workspace       <slug>      - Target workspace (uses credentials)                                                    
+  --variable        <variable>  - Variable in key=value format (coerces booleans, numbers, null; @file reads from path)  
+  --variables-json  <json>      - JSON object of variables (merged with --variable, which takes precedence)              
+  --paginate                    - Auto-paginate a single connection field using cursor pagination                        
   --silent                      - Suppress response output (exit code still reflects errors)
 ```

--- a/skills/linear-cli/references/issue.md
+++ b/skills/linear-cli/references/issue.md
@@ -22,6 +22,7 @@ Commands:
   mine, list, l                           - List your issues                                                          
   query, q                                - Query issues with structured filters                                      
   title             [issueId]             - Print the issue title                                                     
+  state             [issueId]             - Print the issue's current state                                           
   start             [issueId]             - Start working on an issue                                                 
   view, v           [issueId]             - View issue details (default) or open in browser/app                       
   url               [issueId]             - Print the issue URL                                                       
@@ -75,11 +76,10 @@ Description:
 
 Options:
 
-  -h, --help             - Show this help.                                                                                
-  --workspace  <slug>    - Target workspace (uses credentials)                                                            
-  -j, --json             - Output as JSON                                                                                 
-  --status     <status>  - Filter by session status             (Values: "pending", "active", "complete", "awaitingInput",
-                                                                "error", "stale")
+  -h, --help             - Show this help.                                                                                                  
+  --workspace  <slug>    - Target workspace (uses credentials)                                                                              
+  -j, --json             - Output as JSON                                                                                                   
+  --status     <status>  - Filter by session status             (Values: "pending", "active", "complete", "awaitingInput", "error", "stale")
 ```
 
 ##### view
@@ -111,12 +111,11 @@ Description:
 
 Options:
 
-  -h, --help              - Show this help.                                                                
-  --workspace    <slug>   - Target workspace (uses credentials)                                            
-  -t, --title    <title>  - Custom title for the attachment                                                
-  -c, --comment  <body>   - Create a linked comment with this body; the file remains a sidebar attachment  
-  --public                - Upload images to a public, unauthenticated URL (default: private,              
-                            workspace-members only)
+  -h, --help              - Show this help.                                                                            
+  --workspace    <slug>   - Target workspace (uses credentials)                                                        
+  -t, --title    <title>  - Custom title for the attachment                                                            
+  -c, --comment  <body>   - Create a linked comment with this body; the file remains a sidebar attachment              
+  --public                - Upload images to a public, unauthenticated URL (default: private, workspace-members only)
 ```
 
 ### comment
@@ -156,15 +155,13 @@ Description:
 
 Options:
 
-  -h, --help                - Show this help.                                                                
-  --workspace   <slug>      - Target workspace (uses credentials)                                            
-  -b, --body    <text>      - Comment body text                                                              
-  --body-file   <path>      - Read comment body from a file (preferred for markdown content)                 
-  -p, --parent  <id>        - Parent comment ID for replies                                                  
-  -a, --attach  <filepath>  - Upload a file and add its Markdown link to the comment (images render inline;  
-                              repeatable)                                                                    
-  --public                  - Upload attached images to a public, unauthenticated URL (default: private,     
-                              workspace-members only)
+  -h, --help                - Show this help.                                                                                     
+  --workspace   <slug>      - Target workspace (uses credentials)                                                                 
+  -b, --body    <text>      - Comment body text                                                                                   
+  --body-file   <path>      - Read comment body from a file (preferred for markdown content)                                      
+  -p, --parent  <id>        - Parent comment ID for replies                                                                       
+  -a, --attach  <filepath>  - Upload a file and add its Markdown link to the comment (images render inline; repeatable)           
+  --public                  - Upload attached images to a public, unauthenticated URL (default: private, workspace-members only)
 ```
 
 ##### delete
@@ -245,25 +242,25 @@ Description:
 
 Options:
 
-  -h, --help                                - Show this help.                                                               
-  --workspace                <slug>         - Target workspace (uses credentials)                                           
-  --start                                   - Start the issue after creation                                                
-  -a, --assignee             <assignee>     - Assign the issue to 'self' or someone (by username or name)                   
-  --due-date                 <dueDate>      - Due date of the issue                                                         
-  --parent                   <parent>       - Parent issue (if any) as a team_number code                                   
-  -p, --priority             <priority>     - Priority of the issue (1-4, descending priority)                              
-  --estimate                 <estimate>     - Points estimate of the issue                                                  
-  -d, --description          <description>  - Description of the issue                                                      
-  --description-file         <path>         - Read description from a file (preferred for markdown content)                 
-  -l, --label                <label>        - Issue label associated with the issue. May be repeated.                       
-  --team                     <team>         - Team associated with the issue (if not your default team)                     
-  --project                  <project>      - Project for the issue (UUID, slug ID, or name)                                
-  -s, --state                <state>        - Workflow state for the issue (by name or type)                                
-  --milestone                <milestone>    - Project milestone (UUID, or name when --project is set)                       
-  --cycle                    <cycle>        - Cycle name, number, 'active'/'now', 'next', 'previous', or a relative offset  
-                                              like +1 (use --cycle=-1 for negatives)                                        
-  --no-use-default-template                 - Do not use default template for the issue                                     
-  --no-interactive                          - Disable interactive prompts                                                   
+  -h, --help                                - Show this help.                                                                                         
+  --workspace                <slug>         - Target workspace (uses credentials)                                                                     
+  --start                                   - Start the issue after creation                                                                          
+  -a, --assignee             <assignee>     - Assign the issue to 'self' or someone (by username or name)                                             
+  --due-date                 <dueDate>      - Due date of the issue                                                                                   
+  --parent                   <parent>       - Parent issue (if any) as a team_number code                                                             
+  -p, --priority             <priority>     - Priority of the issue (1-4, descending priority)                                                        
+  --estimate                 <estimate>     - Points estimate of the issue                                                                            
+  -d, --description          <description>  - Description of the issue                                                                                
+  --description-file         <path>         - Read description from a file (preferred for markdown content)                                           
+  -l, --label                <label>        - Issue label associated with the issue. May be repeated.                                                 
+  --team                     <team>         - Team associated with the issue (if not your default team)                                               
+  --project                  <project>      - Project for the issue (UUID, slug ID, or name)                                                          
+  -s, --state                <state>        - Workflow state for the issue (by name or type)                                                          
+  --milestone                <milestone>    - Project milestone (UUID, or name when --project is set)                                                 
+  --cycle                    <cycle>        - Cycle name, number, 'active'/'now', 'next', 'previous', or a relative offset like +1 (use --cycle=-1    
+                                              for negatives)                                                                                          
+  --no-use-default-template                 - Do not use default template for the issue                                                               
+  --no-interactive                          - Disable interactive prompts                                                                             
   -t, --title                <title>        - Title of the issue
 ```
 
@@ -360,24 +357,31 @@ Description:
 
 Options:
 
-  -h, --help                       - Show this help.                                                                                                                         
-  --workspace      <slug>          - Target workspace (uses credentials)                                                                                                     
-  -s, --state      <state>         - Filter by issue state (can be repeated for multiple states)                      (Default: [ "unstarted" ], Values: "triage", "backlog",
-                                                                                                                      "unstarted", "started", "completed", "canceled")       
-  --all-states                     - Show issues from all states                                                                                                             
-  --sort           <sort>          - Sort order (default: priority, can also be set via LINEAR_ISSUE_SORT)            (Values: "manual", "priority")                         
-  --team           <team>          - Team to list issues for (if not your default team)                                                                                      
-  --project        <project>       - Filter by project (UUID, slug ID, or name)                                                                                              
-  --project-label  <projectLabel>  - Filter by project label name (shows issues from all projects with this label)                                                           
-  --cycle          <cycle>         - Filter by cycle name, number, 'active'/'now', 'next', 'previous', or a relative                                                         
-                                     offset like +1                                                                                                                          
-  --milestone      <milestone>     - Filter by project milestone (UUID, or name when --project is set)                                                                       
-  -l, --label      <label>         - Filter by label name (can be repeated for multiple labels)                                                                              
-  --limit          <limit>         - Maximum number of issues to fetch (default: 50, use 0 for unlimited)             (Default: 50)                                          
-  --created-after  <date>          - Filter issues created after this date (ISO 8601 or YYYY-MM-DD)                                                                          
-  --updated-after  <date>          - Filter issues updated after this date (ISO 8601 or YYYY-MM-DD)                                                                          
-  -w, --web                        - Open in web browser                                                                                                                     
-  -a, --app                        - Open in Linear.app                                                                                                                      
+  -h, --help                       - Show this help.                                                                                                 
+  --workspace      <slug>          - Target workspace (uses credentials)                                                                             
+  -s, --state      <state>         - Filter by issue state (can be repeated for multiple   (Default: [ "unstarted" ], Values: "triage", "backlog",   
+                                     states)                                               "unstarted", "started", "completed", "canceled")          
+  --all-states                     - Show issues from all states                                                                                     
+  --sort           <sort>          - Sort order (default: priority, can also be set via    (Values: "manual", "priority")                            
+                                     LINEAR_ISSUE_SORT)                                                                                              
+  --team           <team>          - Team to list issues for (if not your default team)                                                              
+  --project        <project>       - Filter by project (UUID, slug ID, or name)                                                                      
+  --project-label  <projectLabel>  - Filter by project label name (shows issues from all                                                             
+                                     projects with this label)                                                                                       
+  --cycle          <cycle>         - Filter by cycle name, number, 'active'/'now',                                                                   
+                                     'next', 'previous', or a relative offset like +1                                                                
+  --milestone      <milestone>     - Filter by project milestone (UUID, or name when                                                                 
+                                     --project is set)                                                                                               
+  -l, --label      <label>         - Filter by label name (can be repeated for multiple                                                              
+                                     labels)                                                                                                         
+  --limit          <limit>         - Maximum number of issues to fetch (default: 50, use   (Default: 50)                                             
+                                     0 for unlimited)                                                                                                
+  --created-after  <date>          - Filter issues created after this date (ISO 8601 or                                                              
+                                     YYYY-MM-DD)                                                                                                     
+  --updated-after  <date>          - Filter issues updated after this date (ISO 8601 or                                                              
+                                     YYYY-MM-DD)                                                                                                     
+  -w, --web                        - Open in web browser                                                                                             
+  -a, --app                        - Open in Linear.app                                                                                              
   --no-pager                       - Disable automatic paging for long output
 ```
 
@@ -416,30 +420,36 @@ Description:
 
 Options:
 
-  -h, --help                           - Show this help.                                                                                                                       
-  --workspace          <slug>          - Target workspace (uses credentials)                                                                                                   
-  --search             <term>          - Full-text search term                                                                                                                 
-  --search-comments                    - Also search inside issue comments (requires --search)                                                                                 
-  --team               <team>          - Filter by team key (can be repeated for multiple teams)                                                                               
-  --all-teams                          - Query across all teams                                                                                                                
-  -s, --state          <state>         - Filter by issue state (can be repeated for multiple states)                      (Values: "triage", "backlog", "unstarted", "started",
-                                                                                                                          "completed", "canceled")                             
-  --all-states                         - Show issues from all states (this is the default)                                                                                     
-  --assignee           <assignee>      - Filter by assignee (username)                                                                                                         
-  -A, --all-assignees                  - Show issues for all assignees (this is the default)                                                                                   
-  -U, --unassigned                     - Show only unassigned issues                                                                                                           
-  --sort               <sort>          - Sort order: manual or priority (default: priority, not available with --search)  (Values: "manual", "priority")                       
-  --project            <project>       - Filter by project (UUID, slug ID, or name)                                                                                            
-  --project-label      <projectLabel>  - Filter by project label name (shows issues from all projects with this label)                                                         
-  --cycle              <cycle>         - Filter by cycle name, number, 'active'/'now', 'next', 'previous', or a relative                                                       
-                                         offset like +1                                                                                                                        
-  --milestone          <milestone>     - Filter by project milestone (UUID, or name when --project is set)                                                                     
-  -l, --label          <label>         - Filter by label name (can be repeated for multiple labels)                                                                            
-  --limit              <limit>         - Maximum number of issues to fetch (default: 50, use 0 for unlimited)             (Default: 50)                                        
-  --created-after      <date>          - Filter issues created after this date (ISO 8601 or YYYY-MM-DD)                                                                        
-  --updated-after      <date>          - Filter issues updated after this date (ISO 8601 or YYYY-MM-DD)                                                                        
-  --include-archived                   - Include archived issues                                                                                                               
-  -j, --json                           - Output results as JSON                                                                                                                
+  -h, --help                           - Show this help.                                                                                             
+  --workspace          <slug>          - Target workspace (uses credentials)                                                                         
+  --search             <term>          - Full-text search term                                                                                       
+  --search-comments                    - Also search inside issue comments (requires --search)                                                       
+  --team               <team>          - Filter by team key (can be repeated for multiple teams)                                                     
+  --all-teams                          - Query across all teams                                                                                      
+  -s, --state          <state>         - Filter by issue state (can be repeated for multiple         (Values: "triage", "backlog", "unstarted",      
+                                         states)                                                     "started", "completed", "canceled")             
+  --all-states                         - Show issues from all states (this is the default)                                                           
+  --assignee           <assignee>      - Filter by assignee (username)                                                                               
+  -A, --all-assignees                  - Show issues for all assignees (this is the default)                                                         
+  -U, --unassigned                     - Show only unassigned issues                                                                                 
+  --sort               <sort>          - Sort order: manual or priority (default: priority, not      (Values: "manual", "priority")                  
+                                         available with --search)                                                                                    
+  --project            <project>       - Filter by project (UUID, slug ID, or name)                                                                  
+  --project-label      <projectLabel>  - Filter by project label name (shows issues from all                                                         
+                                         projects with this label)                                                                                   
+  --cycle              <cycle>         - Filter by cycle name, number, 'active'/'now', 'next',                                                       
+                                         'previous', or a relative offset like +1                                                                    
+  --milestone          <milestone>     - Filter by project milestone (UUID, or name when --project                                                   
+                                         is set)                                                                                                     
+  -l, --label          <label>         - Filter by label name (can be repeated for multiple labels)                                                  
+  --limit              <limit>         - Maximum number of issues to fetch (default: 50, use 0 for   (Default: 50)                                   
+                                         unlimited)                                                                                                  
+  --created-after      <date>          - Filter issues created after this date (ISO 8601 or                                                          
+                                         YYYY-MM-DD)                                                                                                 
+  --updated-after      <date>          - Filter issues updated after this date (ISO 8601 or                                                          
+                                         YYYY-MM-DD)                                                                                                 
+  --include-archived                   - Include archived issues                                                                                     
+  -j, --json                           - Output results as JSON                                                                                      
   --no-pager                           - Disable automatic paging for long output
 ```
 
@@ -541,6 +551,24 @@ Options:
   -b, --branch         <branch>   - Custom branch name to use instead of the issue identifier
 ```
 
+### state
+
+> Print the issue's current state
+
+```
+Usage:   linear issue state [issueId]
+
+Description:
+
+  Print the issue's current state
+
+Options:
+
+  -h, --help           - Show this help.                      
+  --workspace  <slug>  - Target workspace (uses credentials)  
+  -j, --json           - Output as JSON
+```
+
 ### title
 
 > Print the issue title
@@ -571,26 +599,24 @@ Description:
 
 Options:
 
-  -h, --help                         - Show this help.                                                                  
-  --workspace         <slug>         - Target workspace (uses credentials)                                              
-  -a, --assignee      <assignee>     - Assign the issue to 'self' or someone (by username or name)                      
-  --unassign                         - Clear the issue's assignee (cannot be combined with --assignee)                  
-  --due-date          <dueDate>      - Due date of the issue                                                            
-  --parent            <parent>       - Parent issue (if any) as a team_number code                                      
-  -p, --priority      <priority>     - Priority of the issue (1-4, descending priority)                                 
-  --estimate          <estimate>     - Points estimate of the issue                                                     
-  -d, --description   <description>  - Description of the issue                                                         
-  --description-file  <path>         - Read description from a file (preferred for markdown content)                    
-  -l, --label         <label>        - Issue label associated with the issue. May be repeated.                          
-  --team              <team>         - Team associated with the issue (if not your default team)                        
-  --project           <project>      - Project to assign the issue to (UUID, slug ID, or name)                          
-  -s, --state         <state>        - Workflow state for the issue (by name or type)                                   
-  --milestone         <milestone>    - Project milestone (UUID, or name when --project is set or the issue already has  
-                                       a project)                                                                       
-  --cycle             <cycle>        - Cycle name, number, 'active'/'now', 'next', 'previous', or a relative offset     
-                                       like +1 (use --cycle=-1 for negatives). Use --clear-cycle to remove the issue    
-                                       from its cycle                                                                   
-  --clear-cycle                      - Remove the issue from its cycle                                                  
+  -h, --help                         - Show this help.                                                                                                
+  --workspace         <slug>         - Target workspace (uses credentials)                                                                            
+  -a, --assignee      <assignee>     - Assign the issue to 'self' or someone (by username or name)                                                    
+  --unassign                         - Clear the issue's assignee (cannot be combined with --assignee)                                                
+  --due-date          <dueDate>      - Due date of the issue                                                                                          
+  --parent            <parent>       - Parent issue (if any) as a team_number code                                                                    
+  -p, --priority      <priority>     - Priority of the issue (1-4, descending priority)                                                               
+  --estimate          <estimate>     - Points estimate of the issue                                                                                   
+  -d, --description   <description>  - Description of the issue                                                                                       
+  --description-file  <path>         - Read description from a file (preferred for markdown content)                                                  
+  -l, --label         <label>        - Issue label associated with the issue. May be repeated.                                                        
+  --team              <team>         - Team associated with the issue (if not your default team)                                                      
+  --project           <project>      - Project to assign the issue to (UUID, slug ID, or name)                                                        
+  -s, --state         <state>        - Workflow state for the issue (by name or type)                                                                 
+  --milestone         <milestone>    - Project milestone (UUID, or name when --project is set or the issue already has a project)                     
+  --cycle             <cycle>        - Cycle name, number, 'active'/'now', 'next', 'previous', or a relative offset like +1 (use --cycle=-1 for       
+                                       negatives). Use --clear-cycle to remove the issue from its cycle                                               
+  --clear-cycle                      - Remove the issue from its cycle                                                                                
   -t, --title         <title>        - Title of the issue
 ```
 

--- a/skills/linear-cli/references/milestone.md
+++ b/skills/linear-cli/references/milestone.md
@@ -18,11 +18,11 @@ Options:
 
 Commands:
 
-  list                  - List milestones for a project                                                 
-  view, v  <milestone>  - View milestone details. By default lists the first 10 attached issues from the
-                          first page of 50; use --all to paginate the full set.                         
-  create                - Create a new project milestone                                                
-  update   <id>         - Update an existing project milestone                                          
+  list                  - List milestones for a project                                                                                               
+  view, v  <milestone>  - View milestone details. By default lists the first 10 attached issues from the first page of 50; use --all to paginate the  
+                          full set.                                                                                                                   
+  create                - Create a new project milestone                                                                                              
+  update   <id>         - Update an existing project milestone                                                                                        
   delete   <id>         - Delete a project milestone
 ```
 

--- a/skills/linear-cli/references/project.md
+++ b/skills/linear-cli/references/project.md
@@ -40,26 +40,25 @@ Description:
 
 Options:
 
-  -h, --help                             - Show this help.                                                             
-  --workspace             <slug>         - Target workspace (uses credentials)                                         
-  -n, --name              <name>         - Project name (required)                                                     
-  -d, --description       <description>  - Project description (max 255 characters, enforced by Linear's API)          
-  -f, --description-file  <path>         - Read project description from file (still subject to the 255-character API  
-                                           limit)                                                                      
-  --content               <markdown>     - Project overview markdown                                                   
-  --content-file          <path>         - Read project overview markdown from a file                                  
-  -t, --team              <team>         - Team key (required, can be repeated for multiple teams)                     
-  -l, --lead              <lead>         - Project lead (username, email, or @me)                                      
-  -s, --status            <status>       - Project status (planned, started, paused, completed, canceled, backlog)     
-  --start-date            <startDate>    - Start date (YYYY-MM-DD)                                                     
-  --target-date           <targetDate>   - Target completion date (YYYY-MM-DD)                                         
-  --priority              <priority>     - Project priority (none, urgent, high, medium, low)                          
-  --label                 <label>        - Project label associated with the project. May be repeated.                 
-  --member                <user>         - Project member (username, email, display name, or @me). May be repeated.    
-  --icon                  <icon>         - Project icon                                                                
-  --color                 <color>        - Project color as a HEX string                                               
-  --initiative            <initiative>   - Add to initiative immediately (ID, slug, or name)                           
-  -i, --interactive                      - Interactive mode (default if no flags provided)                             
+  -h, --help                             - Show this help.                                                                    
+  --workspace             <slug>         - Target workspace (uses credentials)                                                
+  -n, --name              <name>         - Project name (required)                                                            
+  -d, --description       <description>  - Project description (max 255 characters, enforced by Linear's API)                 
+  -f, --description-file  <path>         - Read project description from file (still subject to the 255-character API limit)  
+  --content               <markdown>     - Project overview markdown                                                          
+  --content-file          <path>         - Read project overview markdown from a file                                         
+  -t, --team              <team>         - Team key (required, can be repeated for multiple teams)                            
+  -l, --lead              <lead>         - Project lead (username, email, or @me)                                             
+  -s, --status            <status>       - Project status (planned, started, paused, completed, canceled, backlog)            
+  --start-date            <startDate>    - Start date (YYYY-MM-DD)                                                            
+  --target-date           <targetDate>   - Target completion date (YYYY-MM-DD)                                                
+  --priority              <priority>     - Project priority (none, urgent, high, medium, low)                                 
+  --label                 <label>        - Project label associated with the project. May be repeated.                        
+  --member                <user>         - Project member (username, email, display name, or @me). May be repeated.           
+  --icon                  <icon>         - Project icon                                                                       
+  --color                 <color>        - Project color as a HEX string                                                      
+  --initiative            <initiative>   - Add to initiative immediately (ID, slug, or name)                                  
+  -i, --interactive                      - Interactive mode (default if no flags provided)                                    
   -j, --json                             - Output created project as JSON
 ```
 
@@ -117,17 +116,16 @@ Description:
 
 Options:
 
-  -h, --help                             - Show this help.                                                             
-  --workspace             <slug>         - Target workspace (uses credentials)                                         
-  -n, --name              <name>         - Project name                                                                
-  -d, --description       <description>  - Project description (max 255 characters, enforced by Linear's API)          
-  -f, --description-file  <path>         - Read project description from file (still subject to the 255-character API  
-                                           limit)                                                                      
-  -s, --status            <status>       - Status (planned, started, paused, completed, canceled, backlog)             
-  -l, --lead              <lead>         - Project lead (username, email, or @me)                                      
-  --start-date            <startDate>    - Start date (YYYY-MM-DD)                                                     
-  --target-date           <targetDate>   - Target date (YYYY-MM-DD)                                                    
-  -t, --team              <team>         - Team key (can be repeated for multiple teams)                               
+  -h, --help                             - Show this help.                                                                    
+  --workspace             <slug>         - Target workspace (uses credentials)                                                
+  -n, --name              <name>         - Project name                                                                       
+  -d, --description       <description>  - Project description (max 255 characters, enforced by Linear's API)                 
+  -f, --description-file  <path>         - Read project description from file (still subject to the 255-character API limit)  
+  -s, --status            <status>       - Status (planned, started, paused, completed, canceled, backlog)                    
+  -l, --lead              <lead>         - Project lead (username, email, or @me)                                             
+  --start-date            <startDate>    - Start date (YYYY-MM-DD)                                                            
+  --target-date           <targetDate>   - Target date (YYYY-MM-DD)                                                           
+  -t, --team              <team>         - Team key (can be repeated for multiple teams)                                      
   --label                 <label>        - Replace the project's labels. May be repeated to set multiple labels.
 ```
 

--- a/src/commands/issue/issue-state.ts
+++ b/src/commands/issue/issue-state.ts
@@ -1,0 +1,33 @@
+import { Command } from "@cliffy/command"
+import {
+  fetchIssueDetails,
+  fetchIssueDetailsRaw,
+  getIssueIdentifier,
+} from "../../utils/linear.ts"
+import { handleError, ValidationError } from "../../utils/errors.ts"
+
+export const stateCommand = new Command()
+  .name("state")
+  .description("Print the issue's current state")
+  .arguments("[issueId:string]")
+  .option("-j, --json", "Output as JSON")
+  .action(async ({ json }, issueId) => {
+    try {
+      const resolvedId = await getIssueIdentifier(issueId)
+      if (!resolvedId) {
+        throw new ValidationError(
+          "Could not determine issue ID",
+          { suggestion: "Please provide an issue ID like 'ENG-123'." },
+        )
+      }
+      if (json) {
+        const issue = await fetchIssueDetailsRaw(resolvedId, false)
+        console.log(JSON.stringify(issue.state, null, 2))
+        return
+      }
+      const { state } = await fetchIssueDetails(resolvedId, false)
+      console.log(state.name)
+    } catch (error) {
+      handleError(error, "Failed to get issue state")
+    }
+  })

--- a/src/commands/issue/issue.ts
+++ b/src/commands/issue/issue.ts
@@ -13,6 +13,7 @@ import { queryCommand } from "./issue-query.ts"
 import { relationCommand } from "./issue-relation.ts"
 import { agentSessionCommand } from "./issue-agent-session.ts"
 import { startCommand } from "./issue-start.ts"
+import { stateCommand } from "./issue-state.ts"
 import { titleCommand } from "./issue-title.ts"
 import { updateCommand } from "./issue-update.ts"
 import { urlCommand } from "./issue-url.ts"
@@ -30,6 +31,7 @@ export const issueCommand = new Command()
   .command("query", queryCommand)
   .alias("q")
   .command("title", titleCommand)
+  .command("state", stateCommand)
   .command("start", startCommand)
   .command("view", viewCommand)
   .command("url", urlCommand)

--- a/test/commands/issue/__snapshots__/issue-state.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-state.test.ts.snap
@@ -1,0 +1,39 @@
+export const snapshot = {};
+
+snapshot[`Issue State Command - Help Text 1`] = `
+stdout:
+"
+Usage: state [issueId]
+
+Description:
+
+  Print the issue's current state
+
+Options:
+
+  -h, --help  - Show this help.  
+  -j, --json  - Output as JSON   
+
+"
+stderr:
+""
+`;
+
+snapshot[`Issue State Command - Prints Bare State Name 1`] = `
+stdout:
+"In Progress
+"
+stderr:
+""
+`;
+
+snapshot[`Issue State Command - Prints JSON 1`] = `
+stdout:
+'{
+  "name": "In Progress",
+  "color": "#f87462"
+}
+'
+stderr:
+""
+`;

--- a/test/commands/issue/issue-state.test.ts
+++ b/test/commands/issue/issue-state.test.ts
@@ -1,0 +1,136 @@
+import { snapshotTest } from "@cliffy/testing"
+import { stateCommand } from "../../../src/commands/issue/issue-state.ts"
+import { MockLinearServer } from "../../utils/mock_linear_server.ts"
+
+// Common Deno args for permissions
+const denoArgs = ["--allow-all", "--quiet"]
+
+// Test help output
+await snapshotTest({
+  name: "Issue State Command - Help Text",
+  meta: import.meta,
+  colors: false,
+  args: ["--help"],
+  denoArgs,
+  async fn() {
+    await stateCommand.parse()
+  },
+})
+
+// Test default (bare name) output
+await snapshotTest({
+  name: "Issue State Command - Prints Bare State Name",
+  meta: import.meta,
+  colors: false,
+  args: ["TEST-123"],
+  denoArgs,
+  async fn() {
+    const server = new MockLinearServer([
+      {
+        queryName: "GetIssueDetails",
+        variables: { id: "TEST-123" },
+        response: {
+          data: {
+            issue: {
+              identifier: "TEST-123",
+              title: "Fix authentication bug in login flow",
+              description: null,
+              url:
+                "https://linear.app/test-team/issue/TEST-123/fix-authentication-bug-in-login-flow",
+              branchName: "fix/test-123-auth-bug",
+              state: {
+                name: "In Progress",
+                color: "#f87462",
+              },
+              assignee: null,
+              priority: 2,
+              project: null,
+              projectMilestone: null,
+              parent: null,
+              children: {
+                nodes: [],
+              },
+              attachments: {
+                nodes: [],
+              },
+              labels: {
+                nodes: [],
+              },
+            },
+          },
+        },
+      },
+    ])
+
+    try {
+      await server.start()
+      Deno.env.set("LINEAR_GRAPHQL_ENDPOINT", server.getEndpoint())
+      Deno.env.set("LINEAR_API_KEY", "Bearer test-token")
+
+      await stateCommand.parse()
+    } finally {
+      await server.stop()
+      Deno.env.delete("LINEAR_GRAPHQL_ENDPOINT")
+      Deno.env.delete("LINEAR_API_KEY")
+    }
+  },
+})
+
+// Test --json output
+await snapshotTest({
+  name: "Issue State Command - Prints JSON",
+  meta: import.meta,
+  colors: false,
+  args: ["TEST-123", "--json"],
+  denoArgs,
+  async fn() {
+    const server = new MockLinearServer([
+      {
+        queryName: "GetIssueDetails",
+        variables: { id: "TEST-123" },
+        response: {
+          data: {
+            issue: {
+              identifier: "TEST-123",
+              title: "Fix authentication bug in login flow",
+              description: null,
+              url:
+                "https://linear.app/test-team/issue/TEST-123/fix-authentication-bug-in-login-flow",
+              branchName: "fix/test-123-auth-bug",
+              state: {
+                name: "In Progress",
+                color: "#f87462",
+              },
+              assignee: null,
+              priority: 2,
+              project: null,
+              projectMilestone: null,
+              parent: null,
+              children: {
+                nodes: [],
+              },
+              attachments: {
+                nodes: [],
+              },
+              labels: {
+                nodes: [],
+              },
+            },
+          },
+        },
+      },
+    ])
+
+    try {
+      await server.start()
+      Deno.env.set("LINEAR_GRAPHQL_ENDPOINT", server.getEndpoint())
+      Deno.env.set("LINEAR_API_KEY", "Bearer test-token")
+
+      await stateCommand.parse()
+    } finally {
+      await server.stop()
+      Deno.env.delete("LINEAR_GRAPHQL_ENDPOINT")
+      Deno.env.delete("LINEAR_API_KEY")
+    }
+  },
+})


### PR DESCRIPTION
## Summary
- Add `linear issue state` to print an issue's current workflow state, following the existing `title`/`url` single-field getter pattern
- `--json` outputs the raw `{name, color}` object, reusing the `state` selection already present in the shared `GetIssueDetails` query (no GraphQL/schema changes needed)
- Regenerate skill docs (`deno task generate-skill-docs`) to document the new command

## Test plan
- [x] `deno check` and `deno lint` pass
- [x] New tests in `test/commands/issue/issue-state.test.ts` pass (help text, default output, `--json` output)
- [x] Manual smoke test: `linear issue state ENG-123` prints the bare state name; `--json` prints `{"name": "...", "color": "..."}`