### PR TITLE
Fix document list --issue, which never worked

### DIFF
--- a/src/commands/document/document-list.ts
+++ b/src/commands/document/document-list.ts
@@ -1,5 +1,6 @@
 import { Command } from "@cliffy/command"
 import { gql } from "../../__codegen__/gql.ts"
+import type { DocumentFilter } from "../../__codegen__/graphql.ts"
 import { getGraphQLClient } from "../../utils/graphql.ts"
 import { getTimeAgo, padDisplay } from "../../utils/display.ts"
 import { shouldShowSpinner } from "../../utils/hyperlink.ts"
@@ -49,23 +50,14 @@ export const listCommand = new Command()
     spinner?.start()
 
     try {
-      // Build filter based on options
-      // deno-lint-ignore no-explicit-any
-      let filter: any = undefined
-
-      if (project) {
-        filter = {
-          ...filter,
-          project: { slugId: { eq: project } },
+      // Build filter based on options. Stays undefined when neither flag is
+      // passed so the query sends no filter at all.
+      const filter: DocumentFilter | undefined = project || issue
+        ? {
+          project: project ? { slugId: { eq: project } } : undefined,
+          issue: issue ? { id: { eq: issue.toUpperCase() } } : undefined,
         }
-      }
-
-      if (issue) {
-        filter = {
-          ...filter,
-          issue: { identifier: { eq: issue.toUpperCase() } },
-        }
-      }
+        : undefined
 
       const client = getGraphQLClient()
       const result = await client.request(ListDocuments, {

--- a/test/commands/document/__snapshots__/document-list.test.ts.snap
+++ b/test/commands/document/__snapshots__/document-list.test.ts.snap
@@ -52,6 +52,36 @@ stderr:
 ""
 `;
 
+snapshot[`Document List Command - Filter By Issue JSON Output 1`] = `
+stdout:
+'{
+  "nodes": [
+    {
+      "id": "doc-2",
+      "title": "Migration Runbook",
+      "slugId": "a1c27f6d8e04",
+      "url": "https://linear.app/test/document/migration-runbook-a1c27f6d8e04",
+      "updatedAt": "2026-01-20T14:15:00Z",
+      "project": null,
+      "issue": {
+        "identifier": "TC-123",
+        "title": "Plan the migration"
+      },
+      "creator": {
+        "name": "Jane Smith"
+      }
+    }
+  ],
+  "pageInfo": {
+    "hasNextPage": false,
+    "endCursor": null
+  }
+}
+'
+stderr:
+""
+`;
+
 snapshot[`Document List Command - Empty Results 1`] = `
 stdout:
 "No documents found.

--- a/test/commands/document/document-list.test.ts
+++ b/test/commands/document/document-list.test.ts
@@ -15,10 +15,12 @@ await snapshotTest({
   },
 })
 
-// NOTE: Tests for "List All Documents", "Filter By Project", and "Filter By Issue"
-// have been removed because they display relative timestamps (e.g., "3 days ago")
-// which are inherently non-deterministic. The fakeTime solution causes hangs with
-// mock servers (see project-list.test.ts for similar issue).
+// NOTE: The human-readable table tests for "List All Documents", "Filter By Project",
+// and "Filter By Issue" have been removed because they display relative timestamps
+// (e.g., "3 days ago") which are inherently non-deterministic. The fakeTime solution
+// causes hangs with mock servers (see project-list.test.ts for similar issue).
+// Issue filtering is covered below via the --json path, which prints raw timestamps
+// and is therefore deterministic.
 
 // Test JSON output (uses raw timestamps, not relative - deterministic)
 await snapshotTest({
@@ -46,6 +48,61 @@ await snapshotTest({
                   project: { name: "TinyCloud SDK", slugId: "tinycloud-sdk" },
                   issue: null,
                   creator: { name: "John Doe" },
+                },
+              ],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        },
+      },
+    ])
+
+    try {
+      await server.start()
+      Deno.env.set("LINEAR_GRAPHQL_ENDPOINT", server.getEndpoint())
+      Deno.env.set("LINEAR_API_KEY", "Bearer test-token")
+
+      await listCommand.parse()
+    } finally {
+      await server.stop()
+      Deno.env.delete("LINEAR_GRAPHQL_ENDPOINT")
+      Deno.env.delete("LINEAR_API_KEY")
+    }
+  },
+})
+
+// Regression test: --issue must filter on IssueFilter.id, not a non-existent
+// `identifier` field. The mock declares the exact request variables, so a wrong
+// filter shape matches no mock, falls through to the NO_MOCK_CONFIGURED error and
+// fails the test rather than quietly producing different output.
+await snapshotTest({
+  name: "Document List Command - Filter By Issue JSON Output",
+  meta: import.meta,
+  colors: false,
+  args: ["--issue", "TC-123", "--json"],
+  denoArgs: commonDenoArgs,
+  async fn() {
+    const server = new MockLinearServer([
+      {
+        queryName: "ListDocuments",
+        variables: {
+          filter: { issue: { id: { eq: "TC-123" } } },
+          first: 50,
+        },
+        response: {
+          data: {
+            documents: {
+              nodes: [
+                {
+                  id: "doc-2",
+                  title: "Migration Runbook",
+                  slugId: "a1c27f6d8e04",
+                  url:
+                    "https://linear.app/test/document/migration-runbook-a1c27f6d8e04",
+                  updatedAt: "2026-01-20T14:15:00Z",
+                  project: null,
+                  issue: { identifier: "TC-123", title: "Plan the migration" },
+                  creator: { name: "Jane Smith" },
                 },
               ],
               pageInfo: { hasNextPage: false, endCursor: null },


### PR DESCRIPTION
## The bug

`document list --issue <ID>` has never worked. The filter was built as:

```ts
issue: { identifier: { eq: issue.toUpperCase() } }
```

but `IssueFilter` has no `identifier` field — the comparator for the human
identifier is spelled `id`. Linear rejects the variable during coercion, so every
invocation failed before reaching the resolver:

```console
$ linear document list --issue TC-123
✗ Failed to list documents: Variable "$filter" got invalid value { identifier: { eq: "TC-123" } } at "filter.issue"; Field "identifier" is not defined by type "IssueFilter".
```

It fails regardless of whether the issue exists or has documents attached. Broken
since the command was introduced, so this is not a regression. `--project` on the
same command is unaffected.

## The fix

`issue: { id: { eq: ... } }`. `IDComparator` takes the human identifier directly,
so no identifier parsing is needed.

The filter local was `let filter: any = undefined` with `no-explicit-any`
suppressed, which is why the wrong field name compiled. It is now built as a
single annotated `DocumentFilter | undefined` expression, and the lint suppression
is gone. With the annotation in place `deno check` flags the original bug directly:

```
TS2353 [ERROR]: Object literal may only specify known properties, and 'identifier'
does not exist in type 'IssueFilter'.
```

The filter still stays `undefined` when neither flag is passed, so an unfiltered
list sends no filter at all.

## Test

The earlier filter tests here were removed for rendering relative timestamps
(non-deterministic, and `fakeTime` hangs against the mock server). The new test
goes through `--json` instead, which prints raw timestamps, and declares the exact
expected request variables so `MockLinearServer` only matches the correct filter
shape.

It is verified to actually guard the bug, not just to pass:

- Restoring the complete pre-fix block makes it fail at runtime with
  `No mock response configured for this query`, while the other three tests pass.
- It also fails when run with `-- --update`, so a careless snapshot regeneration
  cannot silently re-record a broken filter as expected output. (The mock miss
  exits non-zero, and cliffy fails on that regardless of update mode.)

## Verification

Every `--project`/`--issue` combination was exercised against a local capture
server to confirm what actually goes over the wire:

| Case | `filter` sent |
|---|---|
| no flags | *(key absent)* |
| `--issue TC-123` | `{"issue":{"id":{"eq":"TC-123"}}}` |
| `--issue tc-123` | `{"issue":{"id":{"eq":"TC-123"}}}` |
| `--project p` | `{"project":{"slugId":{"eq":"p"}}}` |
| both | both keys |

The `project`/`issue` keys are set to `undefined` when their flag is absent and are
dropped during serialization, so no phantom key reaches the API. `deno task check`,
`deno lint`, `deno fmt --check` and the full suite (509 tests) pass.

## Known limitation, unchanged by this PR

`.toUpperCase()` is applied to the identifier, which also uppercases a UUID if one
is passed. `IDComparator` accepts UUIDs as well as human identifiers, and
uppercased UUIDs were reported to still match, but that was not independently
verified here. The uppercasing predates this change and is kept so `--issue tc-123`
works; making it conditional would mean adding identifier-vs-UUID parsing, which
felt out of scope for a bug fix.

## Follow-ups (not in this PR)

- Same `any`-typed-filter pattern in `src/commands/label/label-list.ts:61` and
  `src/commands/initiative/initiative-list.ts:123`.
- `MockLinearServer` does not validate variables against the schema, so
  wrong-but-parseable filters can only be caught by pinning variables per test.
- `document list --json` prints the whole connection (`{nodes, pageInfo}`), not a
  bare array — worth a line in the `--json` help text.
