### PR TITLE
Follow-up to #265: report unusable .env files and stop the dotenv hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- linear no longer crashes on startup when `.env` is a directory rather than a file, and no longer hangs forever on a `.env` written to be `source`d by a shell (a self-referential value such as `export PATH=$PATH:/opt/bin` spun the dotenv expander's loop indefinitely). An unusable `.env` is now reported as a warning on stderr and skipped, and the repository-root `.env` is still consulted as a fallback
+
+### Changed
+
+- an unquoted `$VAR` reference in a `LINEAR_`/`GH_`/`GITHUB_` value is now skipped with a warning rather than expanded. Expansion of an unset variable silently produced the string `"undefined"`, and a self-referential one hung. Quoted values are unaffected, since dotenv never expanded those
+
+### Added
+
+- `LINEAR_IGNORE_ENV_FILE=1` skips `.env` loading entirely, for repositories whose `.env` is not dotenv-shaped
+
 ## [2.5.0] - 2026-08-11
 
 ### Changed

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,7 +32,8 @@ export const cli = new Command()
     `Handy linear commands from the command line.
 
 Environment Variables:
-  LINEAR_DEBUG=1    Show full error details including stack traces`,
+  LINEAR_DEBUG=1              Show full error details including stack traces
+  LINEAR_IGNORE_ENV_FILE=1    Skip loading .env files`,
   )
   .globalOption(
     "--workspace <slug:string>",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { parse } from "@std/toml"
-import { join } from "@std/path"
-import { load } from "@std/dotenv"
+import { join, resolve } from "@std/path"
+import { parse as parseDotenv } from "@std/dotenv"
+import { gray, yellow } from "@std/fmt/colors"
 import * as v from "valibot"
 import { ValidationError } from "./utils/errors.ts"
 
@@ -78,41 +79,283 @@ async function loadConfig() {
   }
 }
 
+// Env keys this CLI reads from a .env file. Everything else in the file is
+// none of our business and is never parsed; see selectRelevantAssignments().
+const ALLOWED_ENV_VAR_PREFIXES = ["LINEAR_", "GH_", "GITHUB_"]
+
+// A `KEY=value` assignment, optionally written as a shell-style `export KEY=`.
+const ENV_ASSIGNMENT =
+  /^[ \t]*(?:export[ \t]+)?([A-Za-z_][A-Za-z0-9_]*)[ \t]*=(.*)$/
+
+// Mirrors the expansion syntax @std/dotenv acts on in unquoted values:
+// `${NAME}`, or an unescaped `$NAME`. A `$` that is not a reference
+// (`ENG # $note`, `a$`) is left alone, since it cannot trigger expansion.
+const SHELL_REFERENCE = /\$\{.+?\}|(?<!\\)\$\w+/
+
+/** Opt out of .env loading entirely, for repos whose .env is not dotenv-shaped. */
+function envFileLoadingDisabled(): boolean {
+  const value = Deno.env.get("LINEAR_IGNORE_ENV_FILE")
+  return value === "1" || value === "true"
+}
+
+// Startup warnings go to stderr so they can never corrupt --json output or the
+// shell-completion scripts written to stdout.
+function warnEnvFile(message: string, suggestion?: string) {
+  console.error(yellow(`Warning: ${message}`))
+  if (suggestion != null) {
+    console.error(gray(`  ${suggestion}`))
+  }
+}
+
+function describeEnvFileError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+interface SelectedAssignments {
+  /** A dotenv document containing only the assignments this CLI consumes. */
+  text: string
+  /** Our keys skipped because the value references a shell variable. */
+  skippedExpansionKeys: string[]
+  /** Our keys skipped because the value opens a quote it never closes. */
+  skippedUnterminatedKeys: string[]
+}
+
+/**
+ * Reduce a .env file to just the assignments this CLI consumes, before handing
+ * it to the dotenv parser.
+ *
+ * This is load-bearing, not an optimization. @std/dotenv expands `$VAR`
+ * references in a `while` loop that never terminates when a value refers to
+ * itself, so a single ordinary line like `export PATH=$PATH:/opt/bin` hangs the
+ * CLI forever at startup — no error, no exit. That line is unremarkable in a
+ * .env file written to be `source`d by a shell, which is exactly the kind of
+ * file this hardening exists for. Since the only keys we ever apply are
+ * LINEAR_/GH_/GITHUB_, dropping every other line first removes that whole class
+ * of failure, and also suppresses the parser's per-line warnings about keys that
+ * were never ours to complain about.
+ */
+function selectRelevantAssignments(text: string): SelectedAssignments {
+  const kept: string[] = []
+  const skippedExpansionKeys: string[] = []
+  const skippedUnterminatedKeys: string[] = []
+
+  for (const line of text.split(/\r?\n/)) {
+    const match = ENV_ASSIGNMENT.exec(line)
+    if (match == null) continue
+    const key = match[1]
+    const rawValue = match[2]
+    if (!ALLOWED_ENV_VAR_PREFIXES.some((prefix) => key.startsWith(prefix))) {
+      continue
+    }
+    const value = effectiveValue(rawValue)
+    // A multi-line quoted value would be silently truncated by this line-wise
+    // filter, so refuse it rather than apply half of it.
+    if (value == null) {
+      skippedUnterminatedKeys.push(key)
+      continue
+    }
+    // We deliberately do not expand shell variables: a self-referential value
+    // hangs the parser, and an unset one silently becomes the string
+    // "undefined". Refusing the value and saying so is better than either.
+    if (value.expands && SHELL_REFERENCE.test(value.text)) {
+      skippedExpansionKeys.push(key)
+      continue
+    }
+    // Keep the original text so the dotenv parser, not this filter, remains
+    // responsible for unquoting and escape handling.
+    kept.push(`${key}=${rawValue}`)
+  }
+
+  return {
+    text: kept.join("\n"),
+    skippedExpansionKeys,
+    skippedUnterminatedKeys,
+  }
+}
+
+interface ParsedValue {
+  text: string
+  /**
+   * Whether @std/dotenv would expand `$` references in this value. Only
+   * unquoted values are expanded; both quote styles are taken literally
+   * (verified against @std/dotenv 0.225.6), so a quoted `$NAME` is neither a
+   * hang risk nor a corruption risk and must be kept.
+   */
+  expands: boolean
+}
+
+/**
+ * The value @std/dotenv would see for this assignment, or null when a quote is
+ * opened and never closed on the same line. Used only to decide whether to keep
+ * the line, so that a `#` comment or a quoted `#` is judged the same way the
+ * parser judges it.
+ */
+function effectiveValue(rawValue: string): ParsedValue | null {
+  const value = rawValue.trimStart()
+  const quote = value[0]
+  if (quote === '"' || quote === "'") {
+    for (let i = 1; i < value.length; i++) {
+      if (quote === '"' && value[i] === "\\") {
+        i++
+        continue
+      }
+      if (value[i] === quote) {
+        return { text: value.slice(1, i), expands: false }
+      }
+    }
+    return null
+  }
+  // An unquoted value runs to the first `#`.
+  const comment = value.indexOf("#")
+  return {
+    text: (comment === -1 ? value : value.slice(0, comment)).trimEnd(),
+    expands: true,
+  }
+}
+
+interface LoadedEnvFile {
+  kind: "loaded"
+  vars: Record<string, string>
+  skippedExpansionKeys: string[]
+  skippedUnterminatedKeys: string[]
+}
+
+type EnvFileOutcome =
+  | { kind: "absent" }
+  | { kind: "unusable"; reason: string }
+  | LoadedEnvFile
+
+/**
+ * Read one .env candidate. Never throws: an unusable candidate is reported so
+ * the caller can warn and carry on, because a .env file is optional input and a
+ * broken one must not take down a command that did not need it.
+ */
+async function readEnvFile(path: string): Promise<EnvFileOutcome> {
+  let info: Deno.FileInfo
+  try {
+    info = await Deno.stat(path)
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return { kind: "absent" }
+    return { kind: "unusable", reason: describeEnvFileError(error) }
+  }
+
+  if (info.isDirectory) {
+    return { kind: "unusable", reason: "it is a directory, not a file" }
+  }
+  // Also covers FIFOs, sockets and devices, which would otherwise block the
+  // read forever rather than fail.
+  if (!info.isFile) {
+    return { kind: "unusable", reason: "it is not a regular file" }
+  }
+
+  let text: string
+  try {
+    text = await Deno.readTextFile(path)
+  } catch (error) {
+    // The file can be removed between the stat and the read.
+    if (error instanceof Deno.errors.NotFound) return { kind: "absent" }
+    return { kind: "unusable", reason: describeEnvFileError(error) }
+  }
+
+  const selected = selectRelevantAssignments(text)
+  try {
+    return {
+      kind: "loaded",
+      vars: parseDotenv(selected.text),
+      skippedExpansionKeys: selected.skippedExpansionKeys,
+      skippedUnterminatedKeys: selected.skippedUnterminatedKeys,
+    }
+  } catch (error) {
+    return { kind: "unusable", reason: describeEnvFileError(error) }
+  }
+}
+
+/** Absolute path of the enclosing git work tree, or null if there isn't one. */
+async function getGitRoot(): Promise<string | null> {
+  try {
+    const { success, stdout } = await new Deno.Command("git", {
+      args: ["rev-parse", "--show-toplevel"],
+      stdout: "piped",
+      stderr: "null",
+    }).output()
+    if (!success) return null
+    const root = new TextDecoder().decode(stdout).trim()
+    return root === "" ? null : root
+  } catch {
+    // git is not installed; not an error, there is just no repo root to find.
+    return null
+  }
+}
+
 // Load .env files
 async function loadEnvFiles() {
-  let envVars: Record<string, string> = {}
-  if ((await Deno.stat(".env").catch(() => null))?.isFile) {
-    envVars = await load()
-  } else {
-    try {
-      const gitRoot = new TextDecoder()
-        .decode(
-          await new Deno.Command("git", {
-            args: ["rev-parse", "--show-toplevel"],
-          })
-            .output()
-            .then((output) => output.stdout),
-        )
-        .trim()
+  if (envFileLoadingDisabled()) return
 
-      const gitRootEnvPath = join(gitRoot, ".env")
-      if ((await Deno.stat(gitRootEnvPath).catch(() => null))?.isFile) {
-        envVars = await load({ envPath: gitRootEnvPath })
+  const cwdEnvPath = resolve(".env")
+  let loadedPath = cwdEnvPath
+  let outcome = await readEnvFile(cwdEnvPath)
+
+  if (outcome.kind === "unusable") {
+    warnEnvFile(
+      `Ignoring ${cwdEnvPath}: ${outcome.reason}. No variables were loaded from it.`,
+      "Set LINEAR_IGNORE_ENV_FILE=1 to skip .env loading entirely.",
+    )
+  }
+
+  // Fall back to the repository root only when the working directory did not
+  // provide a usable file, matching the previous precedence.
+  if (outcome.kind !== "loaded") {
+    const gitRoot = await getGitRoot()
+    const gitRootEnvPath = gitRoot == null
+      ? null
+      : resolve(join(gitRoot, ".env"))
+    if (gitRootEnvPath != null && gitRootEnvPath !== cwdEnvPath) {
+      const rootOutcome = await readEnvFile(gitRootEnvPath)
+      if (rootOutcome.kind === "unusable") {
+        warnEnvFile(
+          `Ignoring ${gitRootEnvPath}: ${rootOutcome.reason}. No variables were loaded from it.`,
+          "Set LINEAR_IGNORE_ENV_FILE=1 to skip .env loading entirely.",
+        )
       }
-    } catch {
-      // Silently continue if not in a git repo
+      loadedPath = gitRootEnvPath
+      outcome = rootOutcome
     }
   }
 
+  if (outcome.kind !== "loaded") return
+
   // Apply known environment variables from .env
-  const ALLOWED_ENV_VAR_PREFIXES = ["LINEAR_", "GH_", "GITHUB_"]
-  for (const [key, value] of Object.entries(envVars)) {
-    if (ALLOWED_ENV_VAR_PREFIXES.some((prefix) => key.startsWith(prefix))) {
-      // Use same precedence as dotenv
-      if (Deno.env.get(key) !== undefined) continue
-      Deno.env.set(key, value)
-      dotenvAppliedKeys.add(key)
-    }
+  for (const [key, value] of Object.entries(outcome.vars)) {
+    // Use same precedence as dotenv
+    if (Deno.env.get(key) != null) continue
+    Deno.env.set(key, value)
+    dotenvAppliedKeys.add(key)
+  }
+
+  // Only report values we would otherwise have applied, so a file full of
+  // shell syntax we never consume stays quiet. A key the process environment
+  // already sets would have lost to it anyway, so skipping it changed nothing
+  // and is not worth mentioning.
+  const wouldHaveApplied = (key: string) => Deno.env.get(key) == null
+  const skippedExpansion = outcome.skippedExpansionKeys.filter(wouldHaveApplied)
+  if (skippedExpansion.length > 0) {
+    warnEnvFile(
+      `Ignoring ${skippedExpansion.join(", ")} in ${loadedPath}: the value ` +
+        "references a shell variable, which linear does not expand.",
+      "Write the literal value, or set the variable in your environment instead.",
+    )
+  }
+  const skippedUnterminated = outcome.skippedUnterminatedKeys.filter(
+    wouldHaveApplied,
+  )
+  if (skippedUnterminated.length > 0) {
+    warnEnvFile(
+      `Ignoring ${
+        skippedUnterminated.join(", ")
+      } in ${loadedPath}: the value ` +
+        "opens a quote it never closes on the same line.",
+      "linear does not support values that span multiple lines.",
+    )
   }
 }
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrows } from "@std/assert"
+import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert"
 import { fromFileUrl } from "@std/path"
 import {
   getOption,
@@ -735,11 +735,30 @@ Deno.test("resolveIssueSort - defaults to priority when nothing is configured", 
 // directory as XDG_CONFIG_HOME so one global config file covers both
 // platforms' lookup paths.
 
-async function runTeamSourceSubprocess(options: {
+async function initGitRepo(dir: string): Promise<void> {
+  const { success } = await new Deno.Command("git", {
+    args: ["init", "--quiet"],
+    cwd: dir,
+    stdout: "null",
+    stderr: "null",
+  }).output()
+  if (!success) throw new Error(`git init failed in ${dir}`)
+}
+
+interface TeamSourceRun {
+  result: unknown
+  stderr: string
+}
+
+/**
+ * Like runTeamSourceSubprocess, but returns stderr instead of echoing it, so
+ * tests can assert on the startup warnings config.ts emits there.
+ */
+async function runTeamSourceSubprocessRaw(options: {
   cwd: string
   home: string
   extraEnv?: Record<string, string>
-}): Promise<unknown> {
+}): Promise<TeamSourceRun> {
   const configUrl = new URL("../src/config.ts", import.meta.url)
   const denoJsonPath = fromFileUrl(new URL("../deno.json", import.meta.url))
   const homeDir = Deno.env.get("HOME")
@@ -757,6 +776,8 @@ async function runTeamSourceSubprocess(options: {
       HOME: options.home,
       XDG_CONFIG_HOME: `${options.home}/.config`,
       PATH: Deno.env.get("PATH") ?? "",
+      // Keep startup warnings free of ANSI escapes so tests can match on text.
+      NO_COLOR: "1",
       ...(denoDir == null ? {} : { DENO_DIR: denoDir }),
       ...(Deno.build.os === "windows"
         ? {
@@ -768,13 +789,27 @@ async function runTeamSourceSubprocess(options: {
     },
     stdout: "piped",
     stderr: "piped",
+    // A .env that makes module init hang would otherwise wedge the suite
+    // forever rather than fail; see the shell-variable test below.
+    signal: AbortSignal.timeout(60_000),
   })
   const { stdout, stderr } = await command.output()
-  const errorOutput = new TextDecoder().decode(stderr)
-  if (errorOutput) {
-    console.error("Subprocess stderr:", errorOutput)
+  return {
+    result: JSON.parse(new TextDecoder().decode(stdout).trim()),
+    stderr: new TextDecoder().decode(stderr),
   }
-  return JSON.parse(new TextDecoder().decode(stdout).trim())
+}
+
+async function runTeamSourceSubprocess(options: {
+  cwd: string
+  home: string
+  extraEnv?: Record<string, string>
+}): Promise<unknown> {
+  const { result, stderr } = await runTeamSourceSubprocessRaw(options)
+  if (stderr) {
+    console.error("Subprocess stderr:", stderr)
+  }
+  return result
 }
 
 Deno.test("getOptionWithSource - project config file yields project-config source", async () => {
@@ -846,6 +881,228 @@ Deno.test("getOptionWithSource - a .env directory is ignored, not fatal", async 
     await Deno.mkdir(`${projectDir}/.env`)
     const result = await runTeamSourceSubprocess({ cwd: projectDir, home })
     assertEquals(result, null)
+  } finally {
+    await Deno.remove(projectDir, { recursive: true })
+    await Deno.remove(home, { recursive: true })
+  }
+})
+
+Deno.test("getOptionWithSource - an unusable .env warns on stderr instead of passing silently", async () => {
+  // Staying silent would hide a file the user probably believes is configuring
+  // the CLI, so the compromise is: never fatal, but always say so on stderr.
+  const projectDir = await Deno.makeTempDir()
+  const home = await Deno.makeTempDir()
+  try {
+    await Deno.mkdir(`${projectDir}/.env`)
+    const { result, stderr } = await runTeamSourceSubprocessRaw({
+      cwd: projectDir,
+      home,
+    })
+    assertEquals(result, null)
+    assertStringIncludes(stderr, "Warning: Ignoring")
+    assertStringIncludes(stderr, "it is a directory, not a file")
+    assertStringIncludes(stderr, "LINEAR_IGNORE_ENV_FILE=1")
+  } finally {
+    await Deno.remove(projectDir, { recursive: true })
+    await Deno.remove(home, { recursive: true })
+  }
+})
+
+Deno.test("getOptionWithSource - a .env directory falls back to the repository root .env", async () => {
+  const repoDir = await Deno.makeTempDir()
+  const home = await Deno.makeTempDir()
+  try {
+    await initGitRepo(repoDir)
+    await Deno.writeTextFile(`${repoDir}/.env`, "LINEAR_TEAM_ID=ENG\n")
+    const packageDir = `${repoDir}/packages/app`
+    await Deno.mkdir(`${packageDir}/.env`, { recursive: true })
+    const { result, stderr } = await runTeamSourceSubprocessRaw({
+      cwd: packageDir,
+      home,
+    })
+    assertEquals(result, { value: "ENG", source: "project-env" })
+    assertStringIncludes(stderr, "Warning: Ignoring")
+  } finally {
+    await Deno.remove(repoDir, { recursive: true })
+    await Deno.remove(home, { recursive: true })
+  }
+})
+
+Deno.test("getOptionWithSource - a repository root .env directory is ignored, not fatal", async () => {
+  const repoDir = await Deno.makeTempDir()
+  const home = await Deno.makeTempDir()
+  try {
+    await initGitRepo(repoDir)
+    await Deno.mkdir(`${repoDir}/.env`)
+    const packageDir = `${repoDir}/packages/app`
+    await Deno.mkdir(packageDir, { recursive: true })
+    const { result, stderr } = await runTeamSourceSubprocessRaw({
+      cwd: packageDir,
+      home,
+    })
+    assertEquals(result, null)
+    assertStringIncludes(stderr, "Warning: Ignoring")
+  } finally {
+    await Deno.remove(repoDir, { recursive: true })
+    await Deno.remove(home, { recursive: true })
+  }
+})
+
+Deno.test("getOptionWithSource - a shell-style .env with variable references does not hang startup", async () => {
+  // `export PATH=$PATH:/opt/bin` is ordinary in a .env meant to be sourced by a
+  // shell, and it used to spin @std/dotenv's expansion loop forever, hanging
+  // every command before it dispatched. A regression here fails on the
+  // subprocess timeout rather than returning a wrong value.
+  const projectDir = await Deno.makeTempDir()
+  const home = await Deno.makeTempDir()
+  try {
+    await Deno.writeTextFile(
+      `${projectDir}/.env`,
+      [
+        "export PATH=$PATH:/opt/bin",
+        'if [[ -n "$CI" ]]; then',
+        "  echo building",
+        "fi",
+        "LINEAR_TEAM_ID=ENG",
+        "",
+      ].join("\n"),
+    )
+    const { result, stderr } = await runTeamSourceSubprocessRaw({
+      cwd: projectDir,
+      home,
+    })
+    assertEquals(result, { value: "ENG", source: "project-env" })
+    // PATH is not a key this CLI applies, so skipping it is not worth a warning.
+    assertEquals(stderr, "")
+  } finally {
+    await Deno.remove(projectDir, { recursive: true })
+    await Deno.remove(home, { recursive: true })
+  }
+})
+
+Deno.test("getOptionWithSource - a shell variable reference in a linear key is refused, not silently corrupted", async () => {
+  // The dotenv expander resolves an unset reference to the literal string
+  // "undefined"; refusing the value and saying so beats a corrupt team id.
+  const projectDir = await Deno.makeTempDir()
+  const home = await Deno.makeTempDir()
+  try {
+    await Deno.writeTextFile(
+      `${projectDir}/.env`,
+      "LINEAR_TEAM_ID=$SOME_UNSET_VARIABLE\n",
+    )
+    const { result, stderr } = await runTeamSourceSubprocessRaw({
+      cwd: projectDir,
+      home,
+    })
+    assertEquals(result, null)
+    assertStringIncludes(stderr, "LINEAR_TEAM_ID")
+    assertStringIncludes(stderr, "references a shell variable")
+  } finally {
+    await Deno.remove(projectDir, { recursive: true })
+    await Deno.remove(home, { recursive: true })
+  }
+})
+
+Deno.test("getOptionWithSource - a dollar sign that cannot expand does not block the value", async () => {
+  // Only real `${NAME}` / `$NAME` references are refused. A `$` inside a
+  // trailing comment or a quoted value never reaches the expander, so treating
+  // it as one would drop a perfectly good setting.
+  const projectDir = await Deno.makeTempDir()
+  const home = await Deno.makeTempDir()
+  try {
+    await Deno.writeTextFile(
+      `${projectDir}/.env`,
+      "LINEAR_TEAM_ID=ENG # owned by $TEAM\n",
+    )
+    const { result, stderr } = await runTeamSourceSubprocessRaw({
+      cwd: projectDir,
+      home,
+    })
+    assertEquals(result, { value: "ENG", source: "project-env" })
+    assertEquals(stderr, "")
+  } finally {
+    await Deno.remove(projectDir, { recursive: true })
+    await Deno.remove(home, { recursive: true })
+  }
+})
+
+Deno.test("getOptionWithSource - a quoted value containing a hash is kept intact", async () => {
+  const projectDir = await Deno.makeTempDir()
+  const home = await Deno.makeTempDir()
+  try {
+    await Deno.writeTextFile(
+      `${projectDir}/.env`,
+      'LINEAR_TEAM_ID="ENG # 1"\n',
+    )
+    const { result, stderr } = await runTeamSourceSubprocessRaw({
+      cwd: projectDir,
+      home,
+    })
+    assertEquals(result, { value: "ENG # 1", source: "project-env" })
+    assertEquals(stderr, "")
+  } finally {
+    await Deno.remove(projectDir, { recursive: true })
+    await Deno.remove(home, { recursive: true })
+  }
+})
+
+Deno.test("getOptionWithSource - a quoted dollar reference is kept, since dotenv never expands it", async () => {
+  // @std/dotenv expands `$NAME` only in unquoted values, so a quoted one is
+  // neither a hang risk nor a corruption risk and must survive the filter.
+  const projectDir = await Deno.makeTempDir()
+  const home = await Deno.makeTempDir()
+  try {
+    await Deno.writeTextFile(
+      `${projectDir}/.env`,
+      "LINEAR_TEAM_ID='$ENG'\n",
+    )
+    const { result, stderr } = await runTeamSourceSubprocessRaw({
+      cwd: projectDir,
+      home,
+    })
+    assertEquals(result, { value: "$ENG", source: "project-env" })
+    assertEquals(stderr, "")
+  } finally {
+    await Deno.remove(projectDir, { recursive: true })
+    await Deno.remove(home, { recursive: true })
+  }
+})
+
+Deno.test("getOptionWithSource - a skipped key the environment already sets is not reported", async () => {
+  // The .env value would have lost to the process environment regardless, so
+  // warning that we skipped it would point at a problem that changed nothing.
+  const projectDir = await Deno.makeTempDir()
+  const home = await Deno.makeTempDir()
+  try {
+    await Deno.writeTextFile(
+      `${projectDir}/.env`,
+      "LINEAR_TEAM_ID=$SOME_UNSET_VARIABLE\n",
+    )
+    const { result, stderr } = await runTeamSourceSubprocessRaw({
+      cwd: projectDir,
+      home,
+      extraEnv: { LINEAR_TEAM_ID: "OPS" },
+    })
+    assertEquals(result, { value: "OPS", source: "env" })
+    assertEquals(stderr, "")
+  } finally {
+    await Deno.remove(projectDir, { recursive: true })
+    await Deno.remove(home, { recursive: true })
+  }
+})
+
+Deno.test("getOptionWithSource - LINEAR_IGNORE_ENV_FILE skips .env loading entirely", async () => {
+  const projectDir = await Deno.makeTempDir()
+  const home = await Deno.makeTempDir()
+  try {
+    await Deno.mkdir(`${projectDir}/.env`)
+    const { result, stderr } = await runTeamSourceSubprocessRaw({
+      cwd: projectDir,
+      home,
+      extraEnv: { LINEAR_IGNORE_ENV_FILE: "1" },
+    })
+    assertEquals(result, null)
+    assertEquals(stderr, "")
   } finally {
     await Deno.remove(projectDir, { recursive: true })
     await Deno.remove(home, { recursive: true })


### PR DESCRIPTION
Follow-up to #265 (which fixes #264). Draft until #265 lands — this branch currently contains @jackarch-2's commit too, and will be rebased down to just the delta once #265 is merged.

#265's `?.isFile` check is right, and this builds on it rather than replacing it. Two things it leaves open, both of which hit the setup described in #264:

### The reporter's `.env` files still hang the CLI

#264 says their `.env` files contain zsh syntax because engineers `source` them. A single ordinary line in such a file hangs `linear` forever at startup — no error, no exit:

```sh
echo 'export PATH=$PATH:/opt/bin' > .env
linear --version   # never returns
```

`@std/dotenv` expands `$VAR` references in unquoted values with a `while` loop that never terminates when a value refers to itself. This is worse than the crash #265 fixes (a crash at least prints something), and it's still present in the latest `@std/dotenv` (0.225.8), so a version bump doesn't help.

Since the only keys we ever apply are `LINEAR_`/`GH_`/`GITHUB_`, the fix is to drop every other line before handing the text to the parser. That removes the whole class of failure, and also silences the parser's per-line `console.warn` about invalid identifiers that were never ours to complain about. An unquoted `$` reference in one of *our* keys is refused with a warning rather than expanded — an unset reference otherwise resolves to the literal string `"undefined"`, which is silent corruption of a config value. Quoted values are untouched, since `@std/dotenv` takes those literally and they can't hang (verified against 0.225.6).

### Skipping the file silently hides it

#264 explicitly asks not to be silent — "being entirely silent about the issue may hide deeper issues" — and CLAUDE.md's rule is to never fail silently. So an unusable candidate now prints one yellow warning and continues:

```
Warning: Ignoring /repo/.env: it is a directory, not a file. No variables were loaded from it.
  Set LINEAR_IGNORE_ENV_FILE=1 to skip .env loading entirely.
```

Always stderr, never stdout, so `--json` output and the completion scripts stay machine-readable (QA'd: `completions zsh` emits 93KB of clean stdout with the warning on stderr). `LINEAR_IGNORE_ENV_FILE=1` opts out entirely, which is what keeps the warning from being a permanent per-invocation tax on a repo that will never have a dotenv-shaped `.env`.

### Also folded in

- An unreadable `.env` (mode `000`) passed #265's `isFile` check and then crashed in the read. Read and parse failures are caught too.
- A FIFO `.env` would have blocked the read forever; `isFile` covers that, and it's now exercised by QA.
- The repository-root candidate goes through the same code path instead of a near-copy of it.

### Behavior change worth a look

Unquoted values are no longer shell-expanded. Expansion was already half-broken — unset references became `"undefined"`, self-referential ones hung — and every skipped key is warned about (unless the process environment already overrides it, in which case the `.env` value would have lost anyway), so nothing is dropped quietly.

### Verification

571 tests pass; `deno check`, `deno lint`, `deno fmt --check` clean. 17 provenance tests including all four pre-existing `.env` tests unchanged. Manually QA'd 15 cases against the real CLI: missing / valid / directory / shell-sourced / unreadable / FIFO / symlink / dangling symlink / not-a-git-repo / nested-falls-back-to-root / opt-out, plus stdout cleanliness.