### PR TITLE
Follow-up to #268: cover external and bot comment authors, validate --id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,21 @@
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
-- linear no longer crashes on startup when `.env` is a directory rather than a file, and no longer hangs forever on a `.env` written to be `source`d by a shell (a self-referential value such as `export PATH=$PATH:/opt/bin` spun the dotenv expander's loop indefinitely). An unusable `.env` is now reported as a warning on stderr and skipped, and the repository-root `.env` is still consulted as a fallback
+- issue comment list --json now exposes stable author identity: `user.id`, `externalUser.id`, and a `botActor` object (`id`, `name`, `type`, `subType`) for comments posted by integrations. Display names are editable and can collide across a workspace — an external user's display name can even match a real member's — so programs consuming the JSON previously had nothing reliable to attribute a comment with
+- issue comment list --json now includes `editedAt`, which is set only when a comment's author revised it. `updatedAt` also moves for unrelated backend churn, so it could not answer "has this been changed since it was written?"
+- `LINEAR_IGNORE_ENV_FILE=1` skips `.env` loading entirely, for repositories whose `.env` is not dotenv-shaped
 
 ### Changed
 
 - an unquoted `$VAR` reference in a `LINEAR_`/`GH_`/`GITHUB_` value is now skipped with a warning rather than expanded. Expansion of an unset variable silently produced the string `"undefined"`, and a self-referential one hung. Quoted values are unaffected, since dotenv never expanded those
 
-### Added
+### Fixed
 
-- `LINEAR_IGNORE_ENV_FILE=1` skips `.env` loading entirely, for repositories whose `.env` is not dotenv-shaped
+- linear no longer crashes on startup when `.env` is a directory rather than a file, and no longer hangs forever on a `.env` written to be `source`d by a shell (a self-referential value such as `export PATH=$PATH:/opt/bin` spun the dotenv expander's loop indefinitely). An unusable `.env` is now reported as a warning on stderr and skipped, and the repository-root `.env` is still consulted as a fallback
+- issue comment list showed `@Unknown` for every comment posted by an integration or bot, because the query never asked for `botActor`; those comments now render the bot's name (falling back to its type)
+- issue comment add --id now rejects a value that is not a v4 UUID (the format Linear documents for the field) with an actionable error, instead of forwarding it and surfacing a raw API error
 
 ## [2.5.0] - 2026-08-11
 

--- a/src/commands/issue/issue-comment-add.ts
+++ b/src/commands/issue/issue-comment-add.ts
@@ -13,6 +13,10 @@ import {
 import { shouldShowSpinner } from "../../utils/hyperlink.ts"
 import { CliError, handleError, ValidationError } from "../../utils/errors.ts"
 
+// Linear documents CommentCreateInput.id as "The identifier in UUID v4 format".
+const UUID_V4_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
 export const commentAddCommand = new Command()
   .name("add")
   .description(
@@ -25,6 +29,9 @@ export const commentAddCommand = new Command()
     "Read comment body from a file (preferred for markdown content)",
   )
   .option("-p, --parent <id:string>", "Parent comment ID for replies")
+  // Hidden: a caller-supplied id makes retries idempotent (re-sending the same
+  // id fails rather than posting a duplicate), which is useful to scripts but
+  // noise in the help output.
   .option("--id <uuid:string>", "Caller-supplied UUID for the new comment", {
     hidden: true,
   })
@@ -45,6 +52,22 @@ export const commentAddCommand = new Command()
       if (body && bodyFile) {
         throw new ValidationError(
           "Cannot specify both --body and --body-file",
+        )
+      }
+
+      // Reject a malformed --id here rather than letting the API reject it, so
+      // the user gets an actionable message instead of a raw GraphQL error.
+      // CommentCreateInput.id is documented as "The identifier in UUID v4
+      // format", so check the version and variant nibbles too -- the shared
+      // isLinearUuid() is deliberately lax because it is used to tell UUIDs
+      // apart from names elsewhere, which is a different job.
+      if (id != null && !UUID_V4_REGEX.test(id)) {
+        throw new ValidationError(
+          `Invalid comment ID: ${id}`,
+          {
+            suggestion:
+              "--id must be a v4 UUID, like 123e4567-e89b-42d3-a456-426614174000.",
+          },
         )
       }
 
@@ -171,7 +194,9 @@ export const commentAddCommand = new Command()
         issueId: resolvedIdentifier,
       }
 
-      if (id) input.id = id
+      if (id != null) {
+        input.id = id
+      }
 
       if (parent) {
         input.parentId = parent

--- a/src/commands/issue/issue-comment-list.ts
+++ b/src/commands/issue/issue-comment-list.ts
@@ -6,6 +6,32 @@ import { formatRelativeTime } from "../../utils/display.ts"
 import { bold } from "@std/fmt/colors"
 import { handleError, ValidationError } from "../../utils/errors.ts"
 
+// Structural shape over the generated comment node. A comment is authored by a
+// workspace user, an external user, or an integration; only one is ever set.
+interface CommentAuthorFields {
+  user?: { name: string; displayName: string } | null
+  externalUser?: { name: string; displayName: string } | null
+  botActor?: { name?: string | null; type: string } | null
+}
+
+/**
+ * The name to render for a comment's author.
+ *
+ * Integration-authored comments have neither `user` nor `externalUser`, so they
+ * used to fall all the way through to "Unknown". `botActor` is checked last so
+ * that a comment carrying both a user and a bot actor still renders the human.
+ */
+function formatCommentAuthor(comment: CommentAuthorFields): string {
+  const human = comment.user?.displayName || comment.user?.name ||
+    comment.externalUser?.displayName || comment.externalUser?.name
+  if (human) return human
+
+  const bot = comment.botActor
+  if (bot == null) return "Unknown"
+  // ActorBot.name is nullable; type ("github", "slack", ...) is not.
+  return bot.name || bot.type
+}
+
 export const commentListCommand = new Command()
   .name("list")
   .description("List comments for an issue")
@@ -40,8 +66,15 @@ export const commentListCommand = new Command()
                   displayName
                 }
                 externalUser {
+                  id
                   name
                   displayName
+                }
+                botActor {
+                  id
+                  name
+                  type
+                  subType
                 }
                 parent {
                   id
@@ -118,11 +151,7 @@ export const commentListCommand = new Command()
             new Date(b.createdAt).getTime(),
         )
 
-        const author = rootComment.user?.displayName ||
-          rootComment.user?.name ||
-          rootComment.externalUser?.displayName ||
-          rootComment.externalUser?.name ||
-          "Unknown"
+        const author = formatCommentAuthor(rootComment)
         const date = formatRelativeTime(rootComment.createdAt)
 
         console.log(
@@ -134,9 +163,7 @@ export const commentListCommand = new Command()
         if (threadReplies.length > 0) {
           console.log("")
           for (const reply of threadReplies) {
-            const replyAuthor = reply.user?.displayName || reply.user?.name ||
-              reply.externalUser?.displayName || reply.externalUser?.name ||
-              "Unknown"
+            const replyAuthor = formatCommentAuthor(reply)
             const replyDate = formatRelativeTime(reply.createdAt)
 
             console.log(

--- a/test/commands/issue/__snapshots__/issue-comment-list.test.ts.snap
+++ b/test/commands/issue/__snapshots__/issue-comment-list.test.ts.snap
@@ -33,6 +33,7 @@ stdout:
         "displayName": "Test User"
       },
       "externalUser": null,
+      "botActor": null,
       "parent": null
     }
   ],
@@ -49,6 +50,103 @@ stderr:
 snapshot[`Issue Comment List Command - No Comments 1`] = `
 stdout:
 "No comments found for this issue
+"
+stderr:
+""
+`;
+
+snapshot[`Issue Comment List Command - JSON Output With External And Bot Authors 1`] = `
+stdout:
+'{
+  "nodes": [
+    {
+      "id": "comment-uuid-1",
+      "body": "From a workspace user",
+      "createdAt": "2024-01-15T10:30:00Z",
+      "updatedAt": "2024-01-16T09:00:00Z",
+      "editedAt": null,
+      "url": "https://linear.app/issue/TEST-123#comment-uuid-1",
+      "user": {
+        "id": "user-uuid-123",
+        "name": "testuser",
+        "displayName": "Ada Lovelace"
+      },
+      "externalUser": null,
+      "botActor": null,
+      "parent": null
+    },
+    {
+      "id": "comment-uuid-2",
+      "body": "From an external user with a colliding display name",
+      "createdAt": "2024-01-15T11:00:00Z",
+      "updatedAt": "2024-01-15T11:30:00Z",
+      "editedAt": "2024-01-15T11:30:00Z",
+      "url": "https://linear.app/issue/TEST-123#comment-uuid-2",
+      "user": null,
+      "externalUser": {
+        "id": "external-uuid-456",
+        "name": "ada",
+        "displayName": "Ada Lovelace"
+      },
+      "botActor": null,
+      "parent": null
+    },
+    {
+      "id": "comment-uuid-3",
+      "body": "Merged in abc1234",
+      "createdAt": "2024-01-15T12:00:00Z",
+      "updatedAt": "2024-01-15T12:00:00Z",
+      "editedAt": null,
+      "url": "https://linear.app/issue/TEST-123#comment-uuid-3",
+      "user": null,
+      "externalUser": null,
+      "botActor": {
+        "id": "bot-uuid-789",
+        "name": "GitHub",
+        "type": "github",
+        "subType": "pullRequest"
+      },
+      "parent": null
+    },
+    {
+      "id": "comment-uuid-4",
+      "body": "From a bot with no id",
+      "createdAt": "2024-01-15T13:00:00Z",
+      "updatedAt": "2024-01-15T13:00:00Z",
+      "editedAt": null,
+      "url": "https://linear.app/issue/TEST-123#comment-uuid-4",
+      "user": null,
+      "externalUser": null,
+      "botActor": {
+        "id": null,
+        "name": null,
+        "type": "workflow",
+        "subType": null
+      },
+      "parent": null
+    }
+  ],
+  "pageInfo": {
+    "hasNextPage": false,
+    "endCursor": null
+  }
+}
+'
+stderr:
+""
+`;
+
+snapshot[`Issue Comment List Command - Bot Authors Render A Name 1`] = `
+stdout:
+"@Unknown commented 1/15/2024 [comment-uuid-3]
+Genuinely author-less
+
+@GitHub commented 1/15/2024 [comment-uuid-1]
+Merged in abc1234
+
+  @workflow replied 1/15/2024 [comment-uuid-2]
+  Falls back to the bot type when name is null
+
 "
 stderr:
 ""

--- a/test/commands/issue/issue-comment-add.test.ts
+++ b/test/commands/issue/issue-comment-add.test.ts
@@ -265,3 +265,81 @@ await snapshotTest({
     await commentAddCommand.parse()
   },
 })
+
+// A malformed --id is rejected before any API call, with a message that says how
+// to fix it, rather than surfacing a raw GraphQL error from Linear. Uses the
+// stubbed-Deno.exit pattern because handleError exits rather than returning.
+Deno.test("Issue Comment Add Command - rejects a non-UUID --id", async () => {
+  const errorLogs: string[] = []
+  const errorStub = stub(console, "error", (...args: unknown[]) => {
+    errorLogs.push(args.map(String).join(" "))
+  })
+  const exitStub = stub(Deno, "exit", (_code?: number) => {
+    throw new Error("EXIT")
+  })
+
+  let exited = false
+  try {
+    await commentAddCommand.parse([
+      "TEST-123",
+      "--body",
+      "Nope",
+      "--id",
+      "not-a-uuid",
+    ])
+  } catch (e) {
+    if (!(e instanceof Error) || e.message !== "EXIT") throw e
+    exited = true
+  } finally {
+    errorStub.restore()
+    exitStub.restore()
+  }
+
+  assertEquals(exited, true)
+  assertEquals(
+    errorLogs.some((l) => l.includes("Invalid comment ID: not-a-uuid")),
+    true,
+  )
+  assertEquals(
+    errorLogs.some((l) => l.includes("--id must be a v4 UUID")),
+    true,
+  )
+})
+
+// Linear documents the field as UUID v4 specifically, so a well-formed UUID of
+// another version is still rejected rather than forwarded to fail server-side.
+Deno.test("Issue Comment Add Command - rejects a non-v4 UUID --id", async () => {
+  const errorLogs: string[] = []
+  const errorStub = stub(console, "error", (...args: unknown[]) => {
+    errorLogs.push(args.map(String).join(" "))
+  })
+  const exitStub = stub(Deno, "exit", (_code?: number) => {
+    throw new Error("EXIT")
+  })
+
+  let exited = false
+  try {
+    await commentAddCommand.parse([
+      "TEST-123",
+      "--body",
+      "Nope",
+      "--id",
+      // Valid UUID syntax, but version 1.
+      "123e4567-e89b-12d3-a456-426614174000",
+    ])
+  } catch (e) {
+    if (!(e instanceof Error) || e.message !== "EXIT") throw e
+    exited = true
+  } finally {
+    errorStub.restore()
+    exitStub.restore()
+  }
+
+  assertEquals(exited, true)
+  assertEquals(
+    errorLogs.some((l) =>
+      l.includes("Invalid comment ID: 123e4567-e89b-12d3-a456-426614174000")
+    ),
+    true,
+  )
+})

--- a/test/commands/issue/issue-comment-list.test.ts
+++ b/test/commands/issue/issue-comment-list.test.ts
@@ -134,6 +134,7 @@ await snapshotTest({
                       displayName: "Test User",
                     },
                     externalUser: null,
+                    botActor: null,
                     parent: null,
                   },
                 ],
@@ -187,6 +188,201 @@ await snapshotTest({
                   hasNextPage: false,
                   endCursor: null,
                 },
+              },
+            },
+          },
+        },
+      },
+    ])
+
+    try {
+      await commentListCommand.parse()
+    } finally {
+      await cleanup()
+    }
+  },
+})
+
+// A comment written by an integration has neither `user` nor `externalUser`, so
+// before botActor was selected it carried no author identity at all in --json
+// and rendered as "@Unknown".
+await snapshotTest({
+  name:
+    "Issue Comment List Command - JSON Output With External And Bot Authors",
+  meta: import.meta,
+  colors: false,
+  args: ["TEST-123", "--json"],
+  denoArgs: commonDenoArgs,
+  async fn() {
+    const { cleanup } = await setupMockLinearServer([
+      {
+        queryName: "GetIssueId",
+        variables: { id: "TEST-123" },
+        response: { data: { issue: { id: "issue-uuid-123" } } },
+      },
+      {
+        queryName: "GetIssueComments",
+        queryIncludes: "botActor",
+        response: {
+          data: {
+            issue: {
+              comments: {
+                nodes: [
+                  {
+                    id: "comment-uuid-1",
+                    body: "From a workspace user",
+                    createdAt: "2024-01-15T10:30:00Z",
+                    // updatedAt moved without the author editing anything.
+                    updatedAt: "2024-01-16T09:00:00Z",
+                    editedAt: null,
+                    url: "https://linear.app/issue/TEST-123#comment-uuid-1",
+                    user: {
+                      id: "user-uuid-123",
+                      name: "testuser",
+                      displayName: "Ada Lovelace",
+                    },
+                    externalUser: null,
+                    botActor: null,
+                    parent: null,
+                  },
+                  {
+                    id: "comment-uuid-2",
+                    body: "From an external user with a colliding display name",
+                    createdAt: "2024-01-15T11:00:00Z",
+                    updatedAt: "2024-01-15T11:30:00Z",
+                    // The author did revise this one.
+                    editedAt: "2024-01-15T11:30:00Z",
+                    url: "https://linear.app/issue/TEST-123#comment-uuid-2",
+                    user: null,
+                    externalUser: {
+                      id: "external-uuid-456",
+                      name: "ada",
+                      displayName: "Ada Lovelace",
+                    },
+                    botActor: null,
+                    parent: null,
+                  },
+                  {
+                    id: "comment-uuid-3",
+                    body: "Merged in abc1234",
+                    createdAt: "2024-01-15T12:00:00Z",
+                    updatedAt: "2024-01-15T12:00:00Z",
+                    editedAt: null,
+                    url: "https://linear.app/issue/TEST-123#comment-uuid-3",
+                    user: null,
+                    externalUser: null,
+                    botActor: {
+                      id: "bot-uuid-789",
+                      name: "GitHub",
+                      type: "github",
+                      subType: "pullRequest",
+                    },
+                    parent: null,
+                  },
+                  {
+                    id: "comment-uuid-4",
+                    body: "From a bot with no id",
+                    createdAt: "2024-01-15T13:00:00Z",
+                    updatedAt: "2024-01-15T13:00:00Z",
+                    editedAt: null,
+                    url: "https://linear.app/issue/TEST-123#comment-uuid-4",
+                    user: null,
+                    externalUser: null,
+                    // ActorBot is not a Node; id and name are both nullable.
+                    botActor: {
+                      id: null,
+                      name: null,
+                      type: "workflow",
+                      subType: null,
+                    },
+                    parent: null,
+                  },
+                ],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          },
+        },
+      },
+    ])
+
+    try {
+      await commentListCommand.parse()
+    } finally {
+      await cleanup()
+    }
+  },
+})
+
+await snapshotTest({
+  name: "Issue Comment List Command - Bot Authors Render A Name",
+  meta: import.meta,
+  colors: false,
+  args: ["TEST-123"],
+  denoArgs: commonDenoArgs,
+  async fn() {
+    const { cleanup } = await setupMockLinearServer([
+      {
+        queryName: "GetIssueId",
+        variables: { id: "TEST-123" },
+        response: { data: { issue: { id: "issue-uuid-123" } } },
+      },
+      {
+        queryName: "GetIssueComments",
+        queryIncludes: "botActor",
+        response: {
+          data: {
+            issue: {
+              comments: {
+                nodes: [
+                  {
+                    id: "comment-uuid-1",
+                    body: "Merged in abc1234",
+                    createdAt: "2024-01-15T12:00:00Z",
+                    updatedAt: "2024-01-15T12:00:00Z",
+                    editedAt: null,
+                    url: "https://linear.app/issue/TEST-123#comment-uuid-1",
+                    user: null,
+                    externalUser: null,
+                    botActor: {
+                      id: "bot-uuid-789",
+                      name: "GitHub",
+                      type: "github",
+                      subType: "pullRequest",
+                    },
+                    parent: null,
+                  },
+                  {
+                    id: "comment-uuid-2",
+                    body: "Falls back to the bot type when name is null",
+                    createdAt: "2024-01-15T12:05:00Z",
+                    updatedAt: "2024-01-15T12:05:00Z",
+                    editedAt: null,
+                    url: "https://linear.app/issue/TEST-123#comment-uuid-2",
+                    user: null,
+                    externalUser: null,
+                    botActor: {
+                      id: null,
+                      name: null,
+                      type: "workflow",
+                      subType: null,
+                    },
+                    parent: { id: "comment-uuid-1" },
+                  },
+                  {
+                    id: "comment-uuid-3",
+                    body: "Genuinely author-less",
+                    createdAt: "2024-01-15T12:10:00Z",
+                    updatedAt: "2024-01-15T12:10:00Z",
+                    editedAt: null,
+                    url: "https://linear.app/issue/TEST-123#comment-uuid-3",
+                    user: null,
+                    externalUser: null,
+                    botActor: null,
+                    parent: null,
+                  },
+                ],
+                pageInfo: { hasNextPage: false, endCursor: null },
               },
             },
           },


### PR DESCRIPTION
Follow-up to #268. Draft until #268 lands — this branch currently contains @leonardsellem's commits too, and will be rebased down to just the delta once #268 is merged.

#268 adds `user.id` and `editedAt` to `issue comment list --json`, and the shape is right: it passes the raw connection straight through, so GraphQL field names and nesting are preserved per CLAUDE.md. This fills in the cases it stops short of.

### `externalUser` has the same problem `user` does

It didn't get the same treatment, and the schema is explicit about why it needs it — `ExternalUser.displayName` "Can match the display name of an actual user". So a consumer could disambiguate two workspace members from each other and still not tell a member from an external commenter with the same name. It now carries `id` too.

### Integration-authored comments had *no* author identity at all

This is the bigger gap. A comment posted by GitHub, Slack, or a workflow has `user` **and** `externalUser` both `null`, so it arrived in the JSON with nothing identifying its author — the exact problem #268 sets out to solve, for a whole class of comment it doesn't reach.

Selecting `botActor` gives those comments `type` (non-null, and the reliable key here — `ActorBot` is not a `Node` and its `id` is nullable), plus `subType`, `name`, and `id`.

`botActor.userDisplayName` is available and deliberately left out: it names a person in an external system and is display-only, so it isn't worth the exposure to solve an identity problem the other fields already solve. Easy to add if you disagree.

### A rendering bug we were one field away from

Because the query never asked who the bot was, **every** GitHub/Slack/workflow comment printed as `@Unknown`. Now that we fetch `botActor`, it renders the bot's name (falling back to its `type` when `name` is null):

```
- @Unknown commented 1/15/2024 [comment-uuid-1]
+ @GitHub commented 1/15/2024 [comment-uuid-1]
```

The author fallback was duplicated for root comments and replies; it's now one helper, with `botActor` checked **last** so a comment carrying both a user and a bot actor still renders the human. Every pre-existing snapshot is byte-identical — that's the regression assertion.

### `--id` was forwarded unvalidated

`--id <uuid:string>` is a cliffy `string`, so a typo reached the API and came back as a raw GraphQL error. CLAUDE.md asks for an immediate, actionable error instead. Linear documents `CommentCreateInput.id` as "The identifier in UUID v4 format", so this checks v4 specifically — the shared `isLinearUuid()` is deliberately lax (it's used to tell UUIDs apart from names elsewhere, a different job), so this validation is local:

```
✗ Failed to add comment: Invalid comment ID: nope
  --id must be a v4 UUID, like 123e4567-e89b-42d3-a456-426614174000.
```

The flag stays hidden, now with a comment recording why it exists (caller-supplied ids make retries idempotent).

### Verification

565 tests pass; `deno task check`, `deno lint`, `deno fmt --check` clean; `deno task codegen` produces no further diff. Manually exercised: `--id` absent from `comment add --help`, invalid and non-v4 values rejected with exit 1 and no stack trace, a valid v4 passing validation through to the issue lookup.