### PR TITLE
Add issue templates and CONTRIBUTING with tracker scope

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,52 @@
+name: Bug report
+description: Report a reproducible problem with linear-cli.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Issues are for bugs and feature requests in linear-cli. Usage questions belong in [Discussions](https://github.com/schpet/linear-cli/discussions). See [CONTRIBUTING.md](https://github.com/schpet/linear-cli/blob/main/CONTRIBUTING.md) for what is in scope.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: What linear-cli did, and what you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Commands and inputs needed to reproduce it. Remove API keys and other sensitive data.
+      placeholder: |
+        1. Run `linear ...`
+        2. ...
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `linear --version`.
+      placeholder: linear 2.5.0
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Operating system and how you installed linear-cli.
+      placeholder: macOS 15, installed with Homebrew
+    validations:
+      required: true
+
+  - type: textarea
+    id: output
+    attributes:
+      label: Relevant output
+      description: Error messages or logs. Run with `LINEAR_DEBUG=1` for a stack trace. Remove API keys and other sensitive data.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or usage help
+    url: https://github.com/schpet/linear-cli/discussions
+    about: Ask about installing, configuring, or using linear-cli.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,30 @@
+name: Feature request
+description: Propose a change to linear-cli.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Issues are for bugs and feature requests in linear-cli. Usage questions belong in [Discussions](https://github.com/schpet/linear-cli/discussions). See [CONTRIBUTING.md](https://github.com/schpet/linear-cli/blob/main/CONTRIBUTING.md) for what is in scope.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What were you trying to do, and what got in the way? Describe the use case, not only the fix you have in mind.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: What you would like linear-cli to do.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds or other approaches you looked at.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+## Scope of the issue tracker
+
+Issues are for bugs and feature requests in linear-cli, filed by people using it. Questions about installing, configuring, or using it belong in [Discussions](https://github.com/schpet/linear-cli/discussions).
+
+Do not open issues recommending that linear-cli adopt a library you maintain or are affiliated with. These are closed without discussion.
+
+If you hit a problem using linear-cli that a dependency would solve, file the problem. Naming a library as part of that is fine, but the issue needs to be about the problem you hit, not the library.
+
+Issues outside this scope may be closed.
+
+## Development
+
+linear-cli is written in TypeScript and runs on [Deno](https://deno.com).
+
+```sh
+deno task test      # run the test suite
+deno task validate  # type check, format, lint
+deno task snapshot  # update snapshot tests
+```
+
+After editing a GraphQL document, run `deno task codegen` to regenerate types.
+
+## Pull requests
+
+Keep changes focused, and add tests for new behavior. Tests mirror the source layout: `src/commands/issue/issue-view.ts` is tested by `test/commands/issue/issue-view.test.ts`.


### PR DESCRIPTION
The repo has no issue templates or contributing guide, so every issue starts as a blank box with no stated scope. This adds both, to cut down on off-topic issues and to make the tracker's purpose clear before someone starts typing.

## What this adds

- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues, routes usage questions to Discussions
- `.github/ISSUE_TEMPLATE/bug-report.yml` — required: what happened, repro steps, version, environment
- `.github/ISSUE_TEMPLATE/feature-request.yml` — required: the problem hit, then the proposal
- `CONTRIBUTING.md` — a scope section, plus a short dev/PR section using the existing `deno task` names

## Scope

The tracker is for bugs and feature requests in linear-cli, from people using it. Usage questions go to Discussions. On dependency recommendations, `CONTRIBUTING.md` asks directly:

> Do not open issues recommending that linear-cli adopt a library you maintain or are affiliated with. These are closed without discussion.
>
> If you hit a problem using linear-cli that a dependency would solve, file the problem. Naming a library as part of that is fine, but the issue needs to be about the problem you hit, not the library.

Having this written down means out-of-scope issues get closed by citing a rule rather than an ad-hoc judgment call each time.

## Notes

There is deliberately no "I have read the guidelines" acknowledgement checkbox. It gets ticked without friction by anyone it is aimed at, while legitimate reporters get a meaningless hurdle. The useful friction is the required *problem* field, since it asks for the one thing an off-topic issue does not have.

`blank_issues_enabled: false` removes the blank-issue link from the chooser, but `/issues/new` still works for anyone who navigates there directly. It shapes the default path rather than closing it off.

https://claude.ai/code/session_0131SpUmPyWhkVGNTDHFUkPu